### PR TITLE
Added information on the core and selector classes.

### DIFF
--- a/doc/cheatsheet/cadquery_cheatsheet.html
+++ b/doc/cheatsheet/cadquery_cheatsheet.html
@@ -136,6 +136,27 @@
           </tr>
         </table>
       </div>
+      <div class="section">
+        <h2>Core Classes</h2><br />
+        <table style="width:100%;">
+          <tr>
+            <th style="width:40%;">Class</th>
+            <th style="width:60%;">Description</th>
+          </tr>
+          <tr>
+            <td>CQ(obj)</td>
+            <td>Provides enhanced functionality for a wrapped CAD primitive.</td>
+          </tr>
+          <tr>
+            <td>Plane(origin, xDir, normal)</td>
+            <td>A 2d coordinate system in space, with the x-y axes on the a plane, and a particular point as the origin.</td>
+          </tr>
+          <tr>
+            <td>Workplane(inPlane[origin, obj])</td>
+            <td>Defines a coordinate system in space, in which 2-d coordinates can be used.</td>
+          </tr>
+        </table>
+      </div>
     </div>
     <div class="column" style="width:600px;">
       <div class="section">
@@ -165,6 +186,43 @@
           <tr>
             <td><a href="http://parametricparts.com/docs/classreference.html#cadfile.cadutils.cadquery.CQ.shells">CQ.shells(selector=None)</a></td>
             <td>Select the shells of objects on the stack, optionally filtering the selection.</td>
+          </tr>
+        </table>
+      </div>
+      <div class="section">
+        <h2>Selector Classes</h2><br />
+        <table style="width:100%;">
+          <tr>
+            <th style="width:40%;">Class</th>
+            <th style="width:60%;">Description</th>
+          </tr>
+          <tr>
+            <td>NearestToPointSelector(pnt)</td>
+            <td>Selects object nearest the provided point.</td>
+          </tr>
+          <tr>
+            <td>ParallelDirSelector(vector[tolerance])</td>
+            <td>Selects objects parallel with the provided direction.</td>
+          </tr>
+          <tr>
+            <td>DirectionSelector(vector[tolerance])</td>
+            <td>Selects objects aligned with the provided direction.</td>
+          </tr>
+          <tr>
+            <td>PerpendicularDirSelector(vector[tolerance])</td>
+            <td>Selects objects perpendicular with the provided direction.</td>
+          </tr>
+          <tr>
+            <td>TypeSelector(typeString)</td>
+            <td>Selects objects of the prescribed topological type.</td>
+          </tr>
+          <tr>
+            <td>DirectionMinMaxSelector(vector[directionMax])</td>
+            <td>Selects objects closest or farthest in the specified direction.</td>
+          </tr>
+          <tr>
+            <td>StringSyntaxSelector(selectorString)</td>
+            <td>Filter lists objects using a simple string syntax.</td>
           </tr>
         </table>
       </div>


### PR DESCRIPTION
This is the state that the cheat sheet ended up in after going through all the documentation. Tables of the class methods and short descriptions could be added, but I was worried about flooding the cheat sheet with too much information.
