### PR TITLE
Added a return statement that was needed to make rotateAboutCenter work ...

### DIFF
--- a/cadquery/CQ.py
+++ b/cadquery/CQ.py
@@ -678,7 +678,7 @@ class CQ(object):
         def _rot(obj):
             startPt = obj.Center()
             endPt = startPt + endVec
-            obj.rotate(startPt,endPt,angleDegrees)
+            return obj.rotate(startPt,endPt,angleDegrees)
 
         return self.each(_rot, False)
 
@@ -1436,7 +1436,6 @@ class Workplane(CQ):
                 r = r.transformShape(self.plane.rG)
             else:
                 r = callBackFunction(obj)
-
 
             if type(r) == Wire:
                 if not r.forConstruction:


### PR DESCRIPTION
...properly. Without that return the each statement doesn't collect the objects from the _rot function callback properly.
