### PR TITLE
Added rotate function at the CQ object level and an associated test

### DIFF
--- a/cadquery/CQ.py
+++ b/cadquery/CQ.py
@@ -682,6 +682,25 @@ class CQ(object):
 
         return self.each(_rot, False)
 
+    def rotate(self, axisStartPoint, axisEndPoint, angleDegrees):
+        """Returns a copy of all of the items on the stack rotated through and angle around the axis of rotation.
+
+        :param axisStartPoint: The first point of the axis of rotation
+        :type axisStartPoint: a 3-tuple of floats
+        :type axisEndPoint: The second point of the axis of rotation
+        :type axisEndPoint: a 3-tuple of floats
+        :param angleDegrees: the rotation angle, in degrees
+        :type angleDegrees: float
+        :returns: a CQ object
+
+        WARNING: the underlying objects are modified, not copied.
+
+            Future Enhancements:
+                A version of this method that returns a transformed copy instead
+                of modifying the originals.
+        """
+        return self.newObject([o.rotate(axisStartPoint, axisEndPoint, angleDegrees) for o in self.objects])
+
     def translate(self,vec):
         """
             Returns a copy of  all of the items on the stack moved by the specified translation vector.

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -195,6 +195,21 @@ class TestCadQuery(BaseTest):
         self.assertEqual(type(r.val()), Solid)
         self.assertEqual(type(r.first().val()),Solid)
 
+    def testRotate(self):
+        """Test solid rotation at the CQ object level."""
+        box = Workplane("XY").box(1, 1, 5)
+        box.rotate((0, 0, 0), (1, 0, 0), 90)
+        startPoint = box.faces("<Y").edges("<X").first().val().startPoint().toTuple()
+        endPoint = box.faces("<Y").edges("<X").first().val().endPoint().toTuple()
+
+        self.assertEqual(-0.5, startPoint[0])
+        self.assertEqual(-0.5, startPoint[1])
+        self.assertEqual(-2.5, startPoint[2])
+        self.assertEqual(-0.5, endPoint[0])
+        self.assertEqual(-0.5, endPoint[1])
+        self.assertEqual(2.5, endPoint[2])
+
+
     def testLoft(self):
         """
             Test making a lofted solid


### PR DESCRIPTION
I was using rotate and translate in a project and noticed that while there was a translate function at the CQ class level, there was no rotate function. This forced me to drop out of the higher CQ level with a val(), and then I couldn't call .toFreecad() on the resulting object after rotation and translation. 

This was not a bug fix, just something to make working with CQ syntax a little cleaner.
