### PR TITLE
Fixed usage of toWorldCoordinates in move and moveTo

### DIFF
--- a/cadquery/CQ.py
+++ b/cadquery/CQ.py
@@ -1137,7 +1137,7 @@ class Workplane(CQ):
             See :py:meth:`move` to do the same thing but using relative dimensions
         """
         newCenter = Vector(x,y,0)
-        return self.newObject([self.plane.toWorldCoordinates(newCenter)])
+        return self.newObject([self.plane.toWorldCoords(newCenter)])
 
     #relative move in current plane, not drawing
     def move(self, xDist=0, yDist=0):
@@ -1157,7 +1157,7 @@ class Workplane(CQ):
         """
         p = self._findFromPoint(True)
         newCenter = p + Vector(xDist,yDist,0)
-        return self.newObject([self.plane.toWorldCoordinates(newCenter)])
+        return self.newObject([self.plane.toWorldCoords(newCenter)])
 
 
     def spline(self,listOfXYTuple,forConstruction=False):

--- a/cadquery/freecad_impl/geom.py
+++ b/cadquery/freecad_impl/geom.py
@@ -421,7 +421,9 @@ class Plane:
 
 
         """
-        if len(tuplePoint) == 2:
+        if isinstance(tuplePoint, Vector):
+            v = tuplePoint
+        elif len(tuplePoint) == 2:
             v = Vector(tuplePoint[0], tuplePoint[1], 0)
         else:
             v = Vector(tuplePoint[0],tuplePoint[1],tuplePoint[2])


### PR DESCRIPTION
Hey, I encountered this bug while checking out your project and thought I might fix it. This is my first time ever doing this so I hope I've done it decently. Anyway, I don't see many commits lately - I hope this project doesn't die since it seems like a promising replacement for openscad.