### PR TITLE
Mirrorfix

### DIFF
--- a/cadquery/CQ.py
+++ b/cadquery/CQ.py
@@ -1261,7 +1261,7 @@ class Workplane(CQ):
         #attempt to consolidate wires together.
         consolidated = n.consolidateWires()
 
-        rotatedWires = self.plane.rotateShapes(consolidated.wires().vals(),matrix)
+        rotatedWires = self.plane.rotateShapes(consolidated.wires().vals(), matrix)
 
         for w in rotatedWires:
             consolidated.objects.append(w)

--- a/cadquery/CQ.py
+++ b/cadquery/CQ.py
@@ -1269,6 +1269,7 @@ class Workplane(CQ):
 
         #attempt again to consolidate all of the wires
         c = consolidated.consolidateWires()
+
         return c
 
     def mirrorY(self):
@@ -1288,7 +1289,6 @@ class Workplane(CQ):
 
             Future Enhancements:
                 mirrorX().mirrorY() should work but doesnt, due to some FreeCAD weirdness
-
         """
         tm = Matrix()
         tm.rotateY(math.pi)
@@ -1307,7 +1307,6 @@ class Workplane(CQ):
 
             Future Enhancements:
                 mirrorX().mirrorY() should work but doesnt, due to some FreeCAD weirdness
-
         """
         tm = Matrix()
         tm.rotateX(math.pi)
@@ -1349,11 +1348,9 @@ class Workplane(CQ):
             If possible, a new object with the results are returned.
             if not possible, the wires remain separated
 
-            FreeCAD has a bug in Part.Wire([]) which does not create wires/edges properly somtimes
-            Additionally, it has a bug where a profile compose of two wires ( rathre than one )
-            also does not work properly
-
-            together these are a real problem.
+            FreeCAD has a bug in Part.Wire([]) which does not create wires/edges properly sometimes
+            Additionally, it has a bug where a profile compose of two wires ( rather than one )
+            also does not work properly. Together these are a real problem.
         """
         wires = self.wires().vals()
         if len(wires) < 2:

--- a/cadquery/freecad_impl/geom.py
+++ b/cadquery/freecad_impl/geom.py
@@ -487,25 +487,30 @@ class Plane:
         for w in listOfShapes:
             mirrored = w.transformGeometry(rotationMatrix.wrapped)
 
-            # Make sure that our mirrored edges meet up and are ordered properly
-            aEdges = w.wrapped.Edges
-            aEdges.extend(mirrored.wrapped.Edges)
-            comp = FreeCADPart.Compound(aEdges)
-            mirroredWire = comp.connectEdgesToWires(False).Wires[0]
+            # If the first vertex of the second wire is not coincident with the first or last vertices of the first wire
+            # we have to fix the wire so that it will mirror correctly
+            if (mirrored.wrapped.Vertexes[0].X == w.wrapped.Vertexes[0].X and mirrored.wrapped.Vertexes[0].Y == w.wrapped.Vertexes[0].Y and mirrored.wrapped.Vertexes[0].Z == w.wrapped.Vertexes[0].Z) or (mirrored.wrapped.Vertexes[0].X == w.wrapped.Vertexes[-1].X and mirrored.wrapped.Vertexes[0].Y == w.wrapped.Vertexes[-1].Y and mirrored.wrapped.Vertexes[0].Z == w.wrapped.Vertexes[-1].Z):
+                 resultWires.append(mirrored)
+            else:
+                # Make sure that our mirrored edges meet up and are ordered properly
+                aEdges = w.wrapped.Edges
+                aEdges.extend(mirrored.wrapped.Edges)
+                comp = FreeCADPart.Compound(aEdges)
+                mirroredWire = comp.connectEdgesToWires(False).Wires[0]
 
-            resultWires.append(cadquery.Shape.cast(mirroredWire))
+                resultWires.append(cadquery.Shape.cast(mirroredWire))
 
         return resultWires
 
 
     def _calcTransforms(self):
         """
-            Computes transformation martrices to convert betwene local and global coordinates
+            Computes transformation martrices to convert between local and global coordinates
         """
         #r is the forward transformation matrix from world to local coordinates
         #ok i will be really honest-- i cannot understand exactly why this works
-        #something bout the order of the transaltion and the rotation.
-        # the double-inverting is strange, and i dont understand it.
+        #something bout the order of the translation and the rotation.
+        # the double-inverting is strange, and I don't understand it.
         r = FreeCAD.Base.Matrix()
 
         #forward transform must rotate and adjust for origin

--- a/cadquery/freecad_impl/geom.py
+++ b/cadquery/freecad_impl/geom.py
@@ -17,9 +17,10 @@
     License along with this library; If not, see <http://www.gnu.org/licenses/>
 """
 
-import math,sys
+import math
+import cadquery
 import FreeCAD
-#Turns out we don't need the Part module here.
+import Part as FreeCADPart
 
 def sortWiresByBuildOrder(wireList,plane,result=[]):
     """
@@ -403,9 +404,9 @@ class Plane:
             correctly.
 
         """
-        if isinstance(obj,Vector):
+        if isinstance(obj, Vector):
             return Vector(self.fG.multiply(obj.wrapped))
-        elif isinstance(obj,Shape):
+        elif isinstance(obj, cadquery.Shape):
             return obj.transformShape(self.rG)
         else:
             raise ValueError("Dont know how to convert type %s to local coordinates" % str(type(obj)))
@@ -464,7 +465,7 @@ class Plane:
         newP= Plane(self.origin,newXdir,newZdir)
         return newP
 
-    def rotateShapes(self,listOfShapes,rotationMatrix):
+    def rotateShapes(self, listOfShapes, rotationMatrix):
         """
             rotate the listOfShapes by the rotationMatrix supplied.
             @param listOfShapes is a list of shape objects
@@ -480,12 +481,19 @@ class Plane:
         #There might be a better way, but to do this rotation takes 3 steps
         #transform geometry to local coordinates
         #then rotate about x
-        #then transform back to global coordiante
+        #then transform back to global coordinates
 
         resultWires = []
         for w in listOfShapes:
             mirrored = w.transformGeometry(rotationMatrix.wrapped)
-            resultWires.append(mirrored)
+
+            # Make sure that our mirrored edges meet up and are ordered properly
+            aEdges = w.wrapped.Edges
+            aEdges.extend(mirrored.wrapped.Edges)
+            comp = FreeCADPart.Compound(aEdges)
+            mirroredWire = comp.connectEdgesToWires(False).Wires[0]
+
+            resultWires.append(cadquery.Shape.cast(mirroredWire))
 
         return resultWires
 

--- a/cadquery/freecad_impl/geom.py
+++ b/cadquery/freecad_impl/geom.py
@@ -489,8 +489,14 @@ class Plane:
 
             # If the first vertex of the second wire is not coincident with the first or last vertices of the first wire
             # we have to fix the wire so that it will mirror correctly
-            if (mirrored.wrapped.Vertexes[0].X == w.wrapped.Vertexes[0].X and mirrored.wrapped.Vertexes[0].Y == w.wrapped.Vertexes[0].Y and mirrored.wrapped.Vertexes[0].Z == w.wrapped.Vertexes[0].Z) or (mirrored.wrapped.Vertexes[0].X == w.wrapped.Vertexes[-1].X and mirrored.wrapped.Vertexes[0].Y == w.wrapped.Vertexes[-1].Y and mirrored.wrapped.Vertexes[0].Z == w.wrapped.Vertexes[-1].Z):
-                 resultWires.append(mirrored)
+            if (mirrored.wrapped.Vertexes[0].X == w.wrapped.Vertexes[0].X and
+                mirrored.wrapped.Vertexes[0].Y == w.wrapped.Vertexes[0].Y and
+                mirrored.wrapped.Vertexes[0].Z == w.wrapped.Vertexes[0].Z) or \
+                (mirrored.wrapped.Vertexes[0].X == w.wrapped.Vertexes[-1].X and
+                mirrored.wrapped.Vertexes[0].Y == w.wrapped.Vertexes[-1].Y and
+                mirrored.wrapped.Vertexes[0].Z == w.wrapped.Vertexes[-1].Z):
+
+                resultWires.append(mirrored)
             else:
                 # Make sure that our mirrored edges meet up and are ordered properly
                 aEdges = w.wrapped.Edges

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,43 +3,42 @@ import unittest
 import sys
 import os
 
-#from cadquery.freecad_impl.verutil import fc_import
-#FreeCAD = fc_import("FreeCAD")
-#import cadquery.freecad_impl
 import FreeCAD
-
-# P = fc_import("FreeCAD.Part")
-# V = fc_import("FreeCAD").Base.Vector
 
 import Part as P
 from FreeCAD import Vector as V
 
+
 def readFileAsString(fileName):
-    f= open(fileName,'r')
+    f= open(fileName, 'r')
     s = f.read()
     f.close()
     return s
 
-def writeStringToFile(strToWrite,fileName):
-    f = open(fileName,'w')
+
+def writeStringToFile(strToWrite, fileName):
+    f = open(fileName, 'w')
     f.write(strToWrite)
     f.close()
 
 
 def makeUnitSquareWire():
-    return Solid.cast(P.makePolygon([V(0,0,0),V(1,0,0),V(1,1,0),V(0,1,0),V(0,0,0)]))
+    return Solid.cast(P.makePolygon([V(0, 0, 0), V(1, 0, 0), V(1, 1, 0), V(0, 1, 0), V(0, 0, 0)]))
+
 
 def makeUnitCube():
     return makeCube(1.0)
 
+
 def makeCube(size):
-    return Solid.makeBox(size,size,size)
+    return Solid.makeBox(size, size, size)
+
 
 def toTuple(v):
-    "convert a vector or a vertex to a 3-tuple: x,y,z"
+    """convert a vector or a vertex to a 3-tuple: x,y,z"""
     pnt = v
     if type(v) == FreeCAD.Base.Vector:
-        return (v.Point.x,v.Point.y,v.Point.z)
+        return (v.Point.x, v.Point.y, v.Point.z)
     elif type(v) == Vector:
         return v.toTuple()
     else:
@@ -48,8 +47,8 @@ def toTuple(v):
 
 class BaseTest(unittest.TestCase):
 
-    def assertTupleAlmostEquals(self,expected,actual,places):
-        for i,j in zip(actual,expected):
-            self.assertAlmostEquals(i,j,places)
+    def assertTupleAlmostEquals(self, expected, actual, places):
+        for i, j in zip(actual, expected):
+            self.assertAlmostEquals(i, j, places)
 
-__all__ = [ 'TestCadObjects','TestCadQuery','TestCQSelectors','TestWorkplanes','TestExporters','TestCQSelectors','TestImporters']
+__all__ = ['TestCadObjects', 'TestCadQuery', 'TestCQSelectors', 'TestWorkplanes', 'TestExporters', 'TestCQSelectors', 'TestImporters']


### PR DESCRIPTION
I thought that this was going to fix mirrorX and mirrorY chaining, but it only ended up fixing them individually. It's still a big step forward though. It now works even if the vertices of the mirrored wire don't meet up with the first wire properly.