### PR TITLE
fixed NearestToPointSelector failure with tuple as arguments

### DIFF
--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -62,7 +62,7 @@ class NearestToPointSelector(Selector):
     def filter(self,objectList):
 
         def dist(tShape):
-            return tShape.Center().sub(self.pnt).Length
+            return tShape.Center().sub(Vector(*self.pnt)).Length
             #if tShape.ShapeType == 'Vertex':
             #    return tShape.Point.sub(toVector(self.pnt)).Length
             #else:

--- a/tests/TestCQSelectors.py
+++ b/tests/TestCQSelectors.py
@@ -163,12 +163,12 @@ class TestCQSelectors(BaseTest):
         c = CQ(makeUnitCube())
 
         #nearest vertex to origin is (0,0,0)
-        t = Vector(0.1,0.1,0.1)
+        t = (0.1,0.1,0.1)
 
         v = c.vertices(selectors.NearestToPointSelector(t)).vals()[0]
         self.assertTupleAlmostEquals((0.0,0.0,0.0),(v.X,v.Y,v.Z),3)
 
-        t = Vector(0.1,0.1,0.2)
+        t = (0.1,0.1,0.2)
         #nearest edge is the vertical side edge, 0,0,0 -> 0,0,1
         e = c.edges(selectors.NearestToPointSelector(t)).vals()[0]
         v = c.edges(selectors.NearestToPointSelector(t)).vertices().vals()


### PR DESCRIPTION
I have slightly modified NearestToPointSelector to accept tuple argument as documented in the class description. 

    CQ(aCube).vertices(NearestToPointSelector((0,1,0))

Otherwise it requires a Vector type as argument.