### PR TITLE
added chamfer API

### DIFF
--- a/cadquery/CQ.py
+++ b/cadquery/CQ.py
@@ -795,6 +795,44 @@ class CQ(object):
         solid.wrapped = s.wrapped
         return self.newObject([s])
 
+    def chamfer(self, length, length2 = None):
+        """
+        Chamfers a solid on the selected edges.
+
+        The edges on the stack are chamfered. The solid to which the
+        edges belong must be in the parent chain of the selected
+        edges.
+
+        Optional parameter `length2` can be supplied with a different
+        value than `length` for a chamfer that is shorter on one side
+        longer on the other side.
+
+        :param length: the length of the fillet, must be greater than zero
+        :param length2: optional parameter for asymmetrical chamfer
+        :type length: positive float
+        :type length2: positive float
+        :raises: ValueError if at least one edge is not selected
+        :raises: ValueError if the solid containing the edge is not in the chain
+        :returns: cq object with the resulting solid selected.
+
+        This example will create a unit cube, with the top edges chamfered::
+
+            s = Workplane("XY").box(1,1,1).faces("+Z").edges().chamfer(0.1)
+
+        This example will create chamfers longer on the sides::
+
+            s = Workplane("XY").box(1,1,1).faces("+Z").edges().chamfer(0.2, 0.1)
+        """
+        solid = self.findSolid()
+
+        edgeList = self.edges().vals()
+        if len(edgeList) < 1:
+            raise ValueError("Chamfer requires that edges be selected")
+
+        s = solid.chamfer(length, length2, edgeList)
+
+        solid.wrapped = s.wrapped
+        return self.newObject([s])
 
 class Workplane(CQ):
     """

--- a/cadquery/CQ.py
+++ b/cadquery/CQ.py
@@ -817,11 +817,11 @@ class CQ(object):
 
         This example will create a unit cube, with the top edges chamfered::
 
-            s = Workplane("XY").box(1,1,1).faces("+Z").edges().chamfer(0.1)
+            s = Workplane("XY").box(1,1,1).faces("+Z").chamfer(0.1)
 
         This example will create chamfers longer on the sides::
 
-            s = Workplane("XY").box(1,1,1).faces("+Z").edges().chamfer(0.2, 0.1)
+            s = Workplane("XY").box(1,1,1).faces("+Z").chamfer(0.2, 0.1)
         """
         solid = self.findSolid()
 

--- a/cadquery/freecad_impl/shapes.py
+++ b/cadquery/freecad_impl/shapes.py
@@ -812,19 +812,20 @@ class Solid(Shape):
         nativeEdges = [e.wrapped for e in edgeList]
         return Shape.cast(self.wrapped.makeFillet(radius, nativeEdges))
 
-    def chamfer(self, radius, radius2, edgeList):
+    def chamfer(self, length, length2, edgeList):
         """
         Chamfers the specified edges of this solid.
-        :param radius: radius > 0, the radius (length) of the chamfer
-        :param radius2: radius2 > 0, optional parameter for asymmetrical chamfer. Should be `None` if not required.
+        :param length: length > 0, the length (length) of the chamfer
+        :param length2: length2 > 0, optional parameter for asymmetrical chamfer. Should be `None` if not required.
         :param edgeList:  a list of Edge objects, which must belong to this solid
         :return: Chamfered solid
         """
         nativeEdges = [e.wrapped for e in edgeList]
-        if radius2:
-            return Shape.cast(self.wrapped.makeChamfer(radius, radius2, nativeEdges))
+        # note: we prefer 'length' word to 'radius' as opposed to FreeCAD's API
+        if length2:
+            return Shape.cast(self.wrapped.makeChamfer(length, length2, nativeEdges))
         else:
-            return Shape.cast(self.wrapped.makeChamfer(radius, nativeEdges))
+            return Shape.cast(self.wrapped.makeChamfer(length, nativeEdges))
 
     def shell(self, faceList, thickness, tolerance=0.0001):
         """

--- a/cadquery/freecad_impl/shapes.py
+++ b/cadquery/freecad_impl/shapes.py
@@ -812,6 +812,20 @@ class Solid(Shape):
         nativeEdges = [e.wrapped for e in edgeList]
         return Shape.cast(self.wrapped.makeFillet(radius, nativeEdges))
 
+    def chamfer(self, radius, radius2, edgeList):
+        """
+        Chamfers the specified edges of this solid.
+        :param radius: radius > 0, the radius (length) of the chamfer
+        :param radius2: radius2 > 0, optional parameter for asymmetrical chamfer. Should be `None` if not required.
+        :param edgeList:  a list of Edge objects, which must belong to this solid
+        :return: Chamfered solid
+        """
+        nativeEdges = [e.wrapped for e in edgeList]
+        if radius2:
+            return Shape.cast(self.wrapped.makeChamfer(radius, radius2, nativeEdges))
+        else:
+            return Shape.cast(self.wrapped.makeChamfer(radius, nativeEdges))
+
     def shell(self, faceList, thickness, tolerance=0.0001):
         """
             make a shelled solid of given  by removing the list of faces

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -804,6 +804,36 @@ class TestCadQuery(BaseTest):
         self.saveModel(c)
         self.assertEqual(12,c.faces().size() )
 
+    def testChamfer(self):
+        """
+        Test chamfer API with a box shape
+        """
+        cube = CQ(makeUnitCube()).faces(">Z").chamfer(0.1)
+        self.saveModel(cube)
+        self.assertEqual(10, cube.faces().size())
+
+    def testChamferAsymmetrical(self):
+        """
+        Test chamfer API with a box shape for asymmetrical lengths
+        """
+        cube = CQ(makeUnitCube()).faces(">Z").chamfer(0.1, 0.2)
+        self.saveModel(cube)
+        self.assertEqual(10, cube.faces().size())
+
+        # test if edge lengths are different
+        edge = cube.edges(">Z").vals()[0]
+        self.assertAlmostEqual(0.6, edge.Length(), 3)
+        edge = cube.edges("|Z").vals()[0]
+        self.assertAlmostEqual(0.9, edge.Length(), 3)
+
+    def testChamferCylinder(self):
+        """
+        Test chamfer API with a cylinder shape
+        """
+        cylinder = Workplane("XY").circle(1).extrude(1).faces(">Z").chamfer(0.1)
+        self.saveModel(cylinder)
+        self.assertEqual(4, cylinder.faces().size())
+
     def testCounterBores(self):
         """
         Tests making a set of counterbored holes in a face


### PR DESCRIPTION
I've added chamfer API using freecad's `makeChamfer()` function. It's not documented well. [Here](http://forum.freecadweb.org/viewtopic.php?t=5106#p40159) is a forum post mentioning it and [here](https://github.com/FreeCAD/FreeCAD_sf_master/blob/5676c632f63b75955d3376f2fda09f4e892d490c/src/Mod/Part/App/TopoShapePyImp.cpp#L1139) is the source code for it. 

As you can see my implementation is basically a copy of `fillet` function.

Note on  inconsistency of function arguments (`length` vs `radius`): I think "length" is a better name for chamfer argument, but on the freecad side "radius" is used. So I used "radius" in the freecad implementation file, and "lenght" in the cadquery API.

If you guys agree with this pull request, I can add tests as well. 