### PR TITLE
fix clean method by adding dummy methods to Wire and Compound

### DIFF
--- a/cadquery/CQ.py
+++ b/cadquery/CQ.py
@@ -2409,9 +2409,8 @@ class Workplane(CQ):
         `clean` may fail to produce a clean output in some cases such as
         spherical faces.
         """
-        solidRef = self.findSolid(searchStack=True, searchParents=True)
-        if solidRef:
-            t = solidRef.clean()
-            return self.newObject([t])
-        else:
-            raise ValueError("There is no solid to clean!")
+        try:
+            cleanObjects = [obj.clean() for obj in self.objects]
+        except AttributeError:
+            raise AttributeError("%s object doesn't support `clean()` method!" % obj.ShapeType())
+        return self.newObject(cleanObjects)

--- a/cadquery/freecad_impl/shapes.py
+++ b/cadquery/freecad_impl/shapes.py
@@ -481,6 +481,9 @@ class Wire(Shape):
         """
         return Wire(FreeCADPart.makeHelix(pitch, height, radius, angle))
 
+    def clean(self):
+        """This method is not implemented yet."""
+        return self
 
 class Face(Shape):
     def __init__(self, obj):
@@ -882,3 +885,7 @@ class Compound(Shape):
 
     def tessellate(self, tolerance):
         return self.wrapped.tessellate(tolerance)
+
+    def clean(self):
+        """This method is not implemented yet."""
+        return self


### PR DESCRIPTION
This is a fix for #108 .

Currently these object types have clean() methods;

- Solid
- Wire
- Compound

Do you think I should add a clean() method for any other object type?

By the way, if clean() is called on an object that doesn't have a clean() method, an AttributeError exception raised with such message;

    Face object doesn't support `clean()` method!