### PR TITLE
adding boolean/arithmetic selectors

### DIFF
--- a/tests/TestCQSelectors.py
+++ b/tests/TestCQSelectors.py
@@ -274,6 +274,63 @@ class TestCQSelectors(BaseTest):
         fl = c.faces(selectors.BoxSelector((-0.1, 0.4, -0.1), (1.1, 1.1, 1.1), True)).vals()
         self.assertEqual(1, len(fl))
 
+    def testAndSelector(self):
+        c = CQ(makeUnitCube())
+
+        S = selectors.StringSyntaxSelector
+        BS = selectors.BoxSelector
+
+        el = c.edges(selectors.AndSelector(S('|X'), BS((-2,-2,0.1), (2,2,2)))).vals()
+        self.assertEqual(2, len(el))
+
+        # test 'and' (intersection) operator
+        el = c.edges(S('|X') & BS((-2,-2,0.1), (2,2,2))).vals()
+        self.assertEqual(2, len(el))
+
+    def testSumSelector(self):
+        c = CQ(makeUnitCube())
+
+        S = selectors.StringSyntaxSelector
+
+        fl = c.faces(selectors.SumSelector(S(">Z"), S("<Z"))).vals()
+        self.assertEqual(2, len(fl))
+        el = c.edges(selectors.SumSelector(S("|X"), S("|Y"))).vals()
+        self.assertEqual(8, len(el))
+
+        # test the sum operator
+        fl = c.faces(S(">Z") + S("<Z")).vals()
+        self.assertEqual(2, len(fl))
+        el = c.edges(S("|X") + S("|Y")).vals()
+        self.assertEqual(8, len(el))
+
+    def testSubtractSelector(self):
+        c = CQ(makeUnitCube())
+
+        S = selectors.StringSyntaxSelector
+
+        fl = c.faces(selectors.SubtractSelector(S("#Z"), S(">X"))).vals()
+        self.assertEqual(3, len(fl))
+
+        # test the subtract operator
+        fl = c.faces(S("#Z") - S(">X")).vals()
+        self.assertEqual(3, len(fl))
+
+    def testInverseSelector(self):
+        c = CQ(makeUnitCube())
+
+        S = selectors.StringSyntaxSelector
+
+        fl = c.faces(selectors.InverseSelector(S('>Z'))).vals()
+        self.assertEqual(5, len(fl))
+        el = c.faces('>Z').edges(selectors.InverseSelector(S('>X'))).vals()
+        self.assertEqual(3, len(el))
+
+        # test invert operator
+        fl = c.faces(-S('>Z')).vals()
+        self.assertEqual(5, len(fl))
+        el = c.faces('>Z').edges(-S('>X')).vals()
+        self.assertEqual(3, len(el))
+
     def testFaceCount(self):
         c = CQ(makeUnitCube())
         self.assertEqual( 6, c.faces().size() )


### PR DESCRIPTION
This change introduces new selectors that allows existing selectors to be combined with arithmetic/boolean operations.

Example:
```python
import cadquery
from Helpers import show
from cadquery import selectors

box = cadquery.Workplane("XY").box(10,10,10)

s = selectors.StringSyntaxSelector

### select all edges on right and left faces
#box = box.edges((s("|Z") + s("|Y"))).fillet(1)

### select all edges on top and bottom
#box = box.edges(-s("|Z")).fillet(1)
#box = box.edges(s('|X')+s('Y')).fillet(1)
box = box.faces(s('>Z')+s('<Z')).fillet(1)

show(box)
```

Slightly more complicated shape:
```python
import cadquery
from Helpers import show
from cadquery import selectors

box = cadquery.Workplane("XY").box(10,10,10).edges('|Z').\
      chamfer(2.5)

s = selectors.StringSyntaxSelector

# select diagonal edges
box = box.faces(s('>Z')+s('<Z')).edges(-s('|X')-s('Y')).fillet(1)

show(box)
```

I cannot come up with more examples. This was a bit rushed. Please let me know what you think.

PS: This is not direclty related to this pull request but... Behaviour of `min/max` selector is flawed. If there are more than 1 suitable candidates, only one of them is returned *randomly*. For example

     box.edges(">Z")

returns a random edge from the top face. I understand that nature of the `min/max` requires only 1 entity to be returned but I feel like it's okay to return a list in this case. If next operation, for example `workplane()`, requires only 1 entity to be selected it should throw an error.

I'm bringing up this here, because I think fixing this behaviour will make these additions much more useful (if accepted of course).

Also please don't merge. If these changes accepted, I would like to add tests.
