### PR TITLE
Fix min/max selector random behaviour

### DIFF
--- a/cadquery/CQ.py
+++ b/cadquery/CQ.py
@@ -298,6 +298,10 @@ class CQ(object):
             For now you can work around by creating a workplane and then offsetting the center
             afterwards.
         """
+        if len(self.objects) > 1:
+            raise ValueError("Workplane cannot be created if more than"
+                             " 1 object is selected.")
+
         obj = self.objects[0]
 
         def _computeXdir(normal):

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -291,13 +291,13 @@ class DirectionMinMaxSelector(Selector):
             allow '>(0,0,1)' to work.
 
     """
-    def __init__(self,vector,directionMax=True):
+    def __init__(self, vector, directionMax=True, tolerance=0.0001):
         self.vector = vector
         self.max = max
         self.directionMax = directionMax
+        self.TOLERANCE = tolerance
     def filter(self,objectList):
 
-        #then sort by distance from origin, along direction specified
         def distance(tShape):
             return tShape.Center().dot(self.vector)
             #if tShape.ShapeType == 'Vertex':
@@ -306,10 +306,14 @@ class DirectionMinMaxSelector(Selector):
             #    pnt = tShape.Center()
             #return pnt.dot(self.vector)
 
+        # find out the max/min distance
         if self.directionMax:
-            return [ max(objectList,key=distance) ]
+            d = max(map(distance, objectList))
         else:
-            return [ min(objectList,key=distance) ]
+            d = min(map(distance, objectList))
+
+        # return all objects at the max/min distance (within a tolerance)
+        return filter(lambda o: abs(d - distance(o)) < self.TOLERANCE, objectList)
 
 class BinarySelector(Selector):
     """

--- a/tests/TestCQSelectors.py
+++ b/tests/TestCQSelectors.py
@@ -147,6 +147,10 @@ class TestCQSelectors(BaseTest):
         for v in c.faces(">Z").vertices().vals():
             self.assertAlmostEqual(1.0,v.Z,3)
 
+        # test the case of multiple objects at the same distance
+        el = c.edges("<Z").vals()
+        self.assertEqual(4, len(el))
+
     def testMinDistance(self):
         c = CQ(makeUnitCube())
 
@@ -158,6 +162,10 @@ class TestCQSelectors(BaseTest):
         self.assertEqual(4, len(c.faces("<Z").vertices().vals() ))
         for v in c.faces("<Z").vertices().vals():
             self.assertAlmostEqual(0.0,v.Z,3)
+
+        # test the case of multiple objects at the same distance
+        el = c.edges("<Z").vals()
+        self.assertEqual(4, len(el))
 
     def testNearestTo(self):
         c = CQ(makeUnitCube())

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -442,7 +442,7 @@ class TestCadQuery(BaseTest):
         c = CQ( makeUnitCube())                                   #the cube is the context solid
         self.assertEqual(6,c.faces().size())        #cube has six faces
 
-        r = c.faces().workplane().circle(0.125).extrude(0.5,True)     #make a boss, not updating the original
+        r = c.faces('>Z').workplane().circle(0.125).extrude(0.5,True)     #make a boss, not updating the original
         self.assertEqual(8,r.faces().size())                  #just the boss faces
         self.assertEqual(8,c.faces().size())                  #original is modified too
 


### PR DESCRIPTION
This fixes the random selection issue with the min/max selector. Instead all objects within a tolerance are returned.

Also `workplane()` will fail if there are more than 1 object selected. Otherwise it allows random plane generation. I think it's better to warn user about it. Note that I had to change a test which failed because of this change.