### PR TITLE
create workplane from multiple co-planar faces

### DIFF
--- a/cadquery/CQ.py
+++ b/cadquery/CQ.py
@@ -299,10 +299,20 @@ class CQ(object):
             afterwards.
         """
         def _isCoPlanar(f0, f1):
+            """Test if two faces are on the same plane."""
             p0 = f0.Center()
             p1 = f1.Center()
-            n = f0.normalAt()
-            return abs(n.dot(p0.sub(p1)) < self.ctx.tolerance)
+            n0 = f0.normalAt()
+            n1 = f1.normalAt()
+
+            # test normals (direction of planes)
+            if not ((abs(n0.x-n1.x) < self.ctx.tolerance) or
+                    (abs(n0.y-n1.y) < self.ctx.tolerance) or
+                    (abs(n0.z-n1.z) < self.ctx.tolerance)):
+                return False
+
+            # test if p1 is on the plane of f0 (offset of planes)
+            return abs(n0.dot(p0.sub(p1)) < self.ctx.tolerance)
 
         def _computeXdir(normal):
             """

--- a/cadquery/CQ.py
+++ b/cadquery/CQ.py
@@ -262,7 +262,6 @@ class CQ(object):
 
     def workplane(self, offset=0.0, invert=False):
         """
-
         Creates a new 2-D workplane, located relative to the first face on the stack.
 
         :param offset:  offset for the work plane in the Z direction. Default
@@ -271,14 +270,18 @@ class CQ(object):
         :type invert: boolean or None=False
         :rtype: Workplane object ( which is a subclass of CQ )
 
-        The first element on the stack must be a face, or a vertex.  If a vertex, then the parent
-        item on the chain immediately before the vertex must be a face.
+        The first element on the stack must be a face, a set of
+        co-planar faces or a vertex.  If a vertex, then the parent
+        item on the chain immediately before the vertex must be a
+        face.
 
         The result will be a 2-d working plane
         with a new coordinate system set up as follows:
 
-           * The origin will be located in the *center* of the face, if a face was selected. If a
-             vertex was selected, the origin will be at the vertex, and located on the face.
+           * The origin will be located in the *center* of the
+             face/faces, if a face/faces was selected. If a vertex was
+             selected, the origin will be at the vertex, and located
+             on the face.
            * The Z direction will be normal to the plane of the face,computed
              at the center point.
            * The X direction will be parallel to the x-y plane. If the workplane is  parallel to

--- a/cadquery/freecad_impl/geom.py
+++ b/cadquery/freecad_impl/geom.py
@@ -98,10 +98,10 @@ class Vector(object):
         return Vector( self.wrapped.cross(v.wrapped))
 
     def dot(self,v):
-        return  self.wrapped.dot(v.wrapped)
+        return self.wrapped.dot(v.wrapped)
 
     def sub(self,v):
-        return self.wrapped.sub(v.wrapped)
+        return Vector(self.wrapped.sub(v.wrapped))
 
     def add(self,v):
         return Vector( self.wrapped.add(v.wrapped))

--- a/cadquery/freecad_impl/shapes.py
+++ b/cadquery/freecad_impl/shapes.py
@@ -198,6 +198,22 @@ class Shape(object):
         else:
             raise ValueError("Cannot find the center of %s object type" % str(type(self.Solids()[0].wrapped)))
 
+    @staticmethod
+    def CombinedCenter(objects):
+        """
+        Calculates the center of mass of multiple objects.
+
+        :param objects: a list of objects with mass
+        """
+        total_mass = sum(o.wrapped.Mass for o in objects)
+        weighted_centers = [o.wrapped.CenterOfMass.multiply(o.wrapped.Mass) for o in objects]
+
+        sum_wc = weighted_centers[0]
+        for wc in weighted_centers[1:] :
+            sum_wc = sum_wc.add(wc)
+
+        return Vector(sum_wc.multiply(1./total_mass))
+
     def Closed(self):
         return self.wrapped.Closed
 

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -480,6 +480,19 @@ class TestCadQuery(BaseTest):
         self.saveModel(r)
         self.assertEqual(7,r.faces().size() )
 
+    def testMultiFaceWorkplane(self):
+        """
+        Test Creation of workplane from multiple co-planar face
+        selection.
+        """
+        s = Workplane('XY').box(1,1,1).faces('>Z').rect(1,0.5).cutBlind(-0.2)
+
+        w = s.faces('>Z').workplane()
+        o = w.objects[0] # origin of the workplane
+        self.assertAlmostEqual(o.x, 0., 3)
+        self.assertAlmostEqual(o.y, 0., 3)
+        self.assertAlmostEqual(o.z, 0.5, 3)
+
     def testTriangularPrism(self):
         s = Workplane("XY").lineTo(1,0).lineTo(1,1).close().extrude(0.2)
         self.saveModel(s)


### PR DESCRIPTION
This change allows creating a workplane from multiple face selection as I mentioned previously [here](https://github.com/dcowden/cadquery/pull/110#issuecomment-139879163).

New workplane is created at the center of mass of all selected faces. `workplane()` *fails* if selected objects are not planar faces, or they are not on the same plane.

Now we can do this;

```python
import cadquery as cq
from Helpers import show

S = cq.selectors.StringSyntaxSelector

r = cq.Workplane("XY").box(1,1,1)

r = r.faces('>Z').workplane().rect(1,0.5).cutBlind(-.2).\
    faces('>Z').workplane().rect(0.5,1).cutBlind(-0.2)

r = r.faces('>Z').workplane().hole(.1) # workplane from 4 faces

show(r)
```
![cq_multifaceworkplane](https://cloud.githubusercontent.com/assets/1479166/9944243/b595dc14-5d8e-11e5-9c22-666489186f24.png)

