### PR TITLE
Add another parameter centerOption='CenterOfMass'  to CQ.workplane([offset, invert])

### DIFF
--- a/cadquery/CQ.py
+++ b/cadquery/CQ.py
@@ -262,7 +262,7 @@ class CQ(object):
 
         return self.objects[0].wrapped
 
-    def workplane(self, offset=0.0, invert=False):
+    def workplane(self, offset=0.0, invert=False, centerOption='CenterOfMass'):
         """
         Creates a new 2-D workplane, located relative to the first face on the stack.
 
@@ -341,7 +341,11 @@ class CQ(object):
             if not all(_isCoPlanar(self.objects[0], f) for f in self.objects[1:]):
                 raise ValueError("Selected faces must be co-planar.")
 
-            center = Shape.CombinedCenter(self.objects)
+	    if centerOption == 'CenterOfMass':            
+		center = Shape.CombinedCenter(self.objects)
+	    elif centerOption == 'CenterOfBoundBox':
+		center = Shape.CombinedCenterOfBoundBox(self.objects)
+
             normal = self.objects[0].normalAt()
             xDir = _computeXdir(normal)
 
@@ -349,12 +353,18 @@ class CQ(object):
             obj = self.objects[0]
 
             if isinstance(obj, Face):
-                center = obj.Center()
+		if centerOption == 'CenterOfMass':
+                    center = obj.Center()
+		elif centerOption == 'CenterOfBoundBox':
+                    center = obj.CenterOfBoundBox()
                 normal = obj.normalAt(center)
                 xDir = _computeXdir(normal)
             else:
                 if hasattr(obj, 'Center'):
-                    center = obj.Center()
+		    if centerOption == 'CenterOfMass':
+		        center = obj.Center()
+		    elif centerOption == 'CenterOfBoundBox':
+		        center = obj.CenterOfBoundBox()
                     normal = self.plane.zDir
                     xDir = self.plane.xDir
                 else:


### PR DESCRIPTION
Following Dave's suggestion for the issue " The relative position is inaccurate #60 " in jmwright/cadquery-freecad-module, I made some changes to the CADQuery code:
1. Add CenterOfBoundBox() and CombinedCenterOfBoundBox() functions into Shape class; 
2. Add another parameter centerOption into CQ.workplane([offset, invert]), and default the parameter to CenterOfMass which is the current behavior.

Thanks for your consideration.