### PR TITLE
Import a STEP file from the web

### DIFF
--- a/cadquery/freecad_impl/importers.py
+++ b/cadquery/freecad_impl/importers.py
@@ -25,6 +25,24 @@ from .shapes import Shape
 import FreeCAD
 import Part
 
+import sys
+
+if sys.version > '3':
+    PY3 = True
+    import urllib.request as urlreader
+    import urllib.parse as urlparse
+else:
+    PY3 = False
+    import urllib as urlreader
+    import urlparse
+    
+def isURL(filename):
+    schemeSpecifier = urlparse.urlparse(filename).scheme
+    if schemeSpecifier == 'http' or schemeSpecifier == 'https' or schemeSpecifier == 'ftp':
+        return True
+    else:
+        return False
+
 class ImportTypes:
     STEP = "STEP"
 
@@ -52,6 +70,19 @@ def importStep(fileName):
         :param fileName: The path and name of the STEP file to be imported
     """
 
+    if isURL(fileName):
+        url = fileName
+        webFile = urlreader.urlopen(url)
+        localFileName = url.split('/')[-1]
+        localFile = open(localFileName, 'w')
+        if PY3:
+            localFile.write(webFile.read().decode('utf-8'))
+        else:
+            localFile.write(webFile.read())    
+        webFile.close()
+        localFile.close()
+        fileName = localFileName
+        
     #Now read and return the shape
     try:
         rshape = Part.read(fileName)

--- a/cadquery/freecad_impl/importers.py
+++ b/cadquery/freecad_impl/importers.py
@@ -26,15 +26,9 @@ import FreeCAD
 import Part
 import sys
 import os
-import platform
-
-if sys.version > '3':
-    PY3 = True
-    import urllib.request as urlreader
-else:
-    PY3 = False
-    import urllib as urlreader
-    
+import urllib as urlreader
+import tempfile
+  
 class ImportTypes:
     STEP = "STEP"
 
@@ -80,20 +74,12 @@ def importStepFromURL(url):
     #Now read and return the shape
     try:
         webFile = urlreader.urlopen(url)
-	if platform.system() == 'Windows':
-        	localFileName = os.environ['TEMP']+'/'+url.split('/')[-1]
-	else:
-		localFileName = "/tmp/"+url.split('/')[-1]
-        localFile = open(localFileName, 'w')
-        if PY3:
-            localFile.write(webFile.read().decode('utf-8'))
-        else:
-            localFile.write(webFile.read())    
+	tempFile = tempfile.NamedTemporaryFile(suffix='.step', delete=False)
+	tempFile.write(webFile.read())
         webFile.close()
-        localFile.close()
-        fileName = localFileName
-      
-	rshape = Part.read(fileName)
+	tempFile.close()  
+
+	rshape = Part.read(tempFile.name)
 
         #Make sure that we extract all the solids
         solids = []

--- a/cadquery/freecad_impl/importers.py
+++ b/cadquery/freecad_impl/importers.py
@@ -24,8 +24,9 @@ from .shapes import Shape
 
 import FreeCAD
 import Part
-
 import sys
+import os
+import platform
 
 if sys.version > '3':
     PY3 = True
@@ -68,24 +69,11 @@ def importStep(fileName):
     """
         Accepts a file name and loads the STEP file into a cadquery shape
         :param fileName: The path and name of the STEP file to be imported
-    """
-
-    if isURL(fileName):
-        url = fileName
-        webFile = urlreader.urlopen(url)
-        localFileName = url.split('/')[-1]
-        localFile = open(localFileName, 'w')
-        if PY3:
-            localFile.write(webFile.read().decode('utf-8'))
-        else:
-            localFile.write(webFile.read())    
-        webFile.close()
-        localFile.close()
-        fileName = localFileName
-        
+    """      
     #Now read and return the shape
     try:
-        rshape = Part.read(fileName)
+	#print fileName        
+	rshape = Part.read(fileName)
 
         #Make sure that we extract all the solids
         solids = []
@@ -95,3 +83,33 @@ def importStep(fileName):
         return cadquery.Workplane("XY").newObject(solids)
     except:
         raise ValueError("STEP File Could not be loaded")
+
+#Loads a STEP file from an URL into a CQ.Workplane object
+def importStepFromURL(url):    
+    #Now read and return the shape
+    try:
+        webFile = urlreader.urlopen(url)
+	if webFile.getcode
+	if platform.system() == 'Windows':
+        	localFileName = os.environ['TEMP']+url.split('/')[-1]
+	else:
+		localFileName = "/tmp/"+url.split('/')[-1]
+        localFile = open(localFileName, 'w')
+        if PY3:
+            localFile.write(webFile.read().decode('utf-8'))
+        else:
+            localFile.write(webFile.read())    
+        webFile.close()
+        localFile.close()
+        fileName = localFileName
+      
+	rshape = Part.read(fileName)
+
+        #Make sure that we extract all the solids
+        solids = []
+        for solid in rshape.Solids:
+            solids.append(Shape.cast(solid))
+
+        return cadquery.Workplane("XY").newObject(solids)
+    except:
+        raise ValueError("STEP File from the URL: " + url + " Could not be loaded")

--- a/cadquery/freecad_impl/importers.py
+++ b/cadquery/freecad_impl/importers.py
@@ -80,9 +80,8 @@ def importStepFromURL(url):
     #Now read and return the shape
     try:
         webFile = urlreader.urlopen(url)
-	if webFile.getcode
 	if platform.system() == 'Windows':
-        	localFileName = os.environ['TEMP']+url.split('/')[-1]
+        	localFileName = os.environ['TEMP']+'/'+url.split('/')[-1]
 	else:
 		localFileName = "/tmp/"+url.split('/')[-1]
         localFile = open(localFileName, 'w')

--- a/cadquery/freecad_impl/importers.py
+++ b/cadquery/freecad_impl/importers.py
@@ -31,19 +31,10 @@ import platform
 if sys.version > '3':
     PY3 = True
     import urllib.request as urlreader
-    import urllib.parse as urlparse
 else:
     PY3 = False
     import urllib as urlreader
-    import urlparse
     
-def isURL(filename):
-    schemeSpecifier = urlparse.urlparse(filename).scheme
-    if schemeSpecifier == 'http' or schemeSpecifier == 'https' or schemeSpecifier == 'ftp':
-        return True
-    else:
-        return False
-
 class ImportTypes:
     STEP = "STEP"
 


### PR DESCRIPTION
This pull request adds a new function importStepFromURL(url), which will firstly download a STEP file from the web, then save the file into a OS's temp directory, finally import the STEP from the temp directory.

Now, I use the tempfile module from the python std library for the temporary file. 
NOTE: the suffix=".step" parameter in the tempfile.NamedTemporaryFile() function is a must, since Part.read need the suffix parameter.

If Part.read() could support memory file reading, we do not need to save the file into disk at all. I hope CQ could support stream-like or memory-file-like file read and write for further other operations.

Here is an example in FreeCAD:
```
import cadquery as cq
from Helpers import show
myShape = cq.importers.importStepFromURL("https://raw.githubusercontent.com/huskier/images/master/SectionBar.step")
myShape.val().label = "SectionBar"
show(myShape)
```