### PR TITLE
Symmetric extrude with respect to the workplane

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1967,7 +1967,7 @@ class Workplane(CQ):
         if clean: newS = newS.clean()
         return newS
 
-    def extrude(self, distance, combine=True, clean=True):
+    def extrude(self, distance, combine=True, clean=True, both=False):
         """
         Use all un-extruded wires in the parent chain to create a prismatic solid.
 
@@ -1975,6 +1975,7 @@ class Workplane(CQ):
         :type distance: float, negative means opposite the normal direction
         :param boolean combine: True to combine the resulting solid with parent solids if found.
         :param boolean clean: call :py:meth:`clean` afterwards to have a clean shape
+        :param boolean both: extrude in both directions symmetrically
         :return: a CQ object with the resulting solid selected.
 
         extrude always *adds* material to a part.
@@ -1990,8 +1991,9 @@ class Workplane(CQ):
             Support for non-prismatic extrusion ( IE, sweeping along a profile, not just
             perpendicular to the plane extrude to surface. this is quite tricky since the surface
             selected may not be planar
-        """
-        r = self._extrude(distance)  # returns a Solid (or a compound if there were multiple)
+        """               
+        r = self._extrude(distance,both=both)  # returns a Solid (or a compound if there were multiple)
+            
         if combine:
             newS = self._combineWithBase(r)
         else:
@@ -2254,11 +2256,12 @@ class Workplane(CQ):
 
         return self.newObject([r])
 
-    def _extrude(self, distance):
+    def _extrude(self, distance, both=False):
         """
         Make a prismatic solid from the existing set of pending wires.
 
         :param distance: distance to extrude
+        :param boolean both: extrude in both directions symmetrically
         :return: a FreeCAD solid, suitable for boolean operations.
 
         This method is a utility method, primarily for plugin and internal use.
@@ -2305,6 +2308,10 @@ class Workplane(CQ):
         for ws in wireSets:
             thisObj = Solid.extrudeLinear(ws[0], ws[1:], eDir)
             toFuse.append(thisObj)
+            
+            if both:
+                thisObj = Solid.extrudeLinear(ws[0], ws[1:], eDir.multiply(-1.))
+                toFuse.append(thisObj)
 
         return Compound.makeCompound(toFuse)
 

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -1387,3 +1387,27 @@ class TestCadQuery(BaseTest):
         result =topOfLid.union(bottom)
 
         self.saveModel(result)
+        
+    def testExtrude(self):
+        """
+        Test symmetric extrude
+        """
+        r = 1.
+        h = 1.
+        decimal_places = 9.
+        
+        #extrude symmetrically
+        s = Workplane("XY").circle(r).extrude(h,both=True)
+        
+        top_face = s.faces(">Z")
+        bottom_face = s.faces("<Z")
+        
+        #calculate the distance between the top and the bottom face        
+        delta = top_face.val().Center().sub(bottom_face.val().Center())
+
+        self.assertTupleAlmostEquals(delta.toTuple(),
+                                     (0.,0.,2.*h),
+                                     decimal_places)
+        
+        
+        


### PR DESCRIPTION
Added additional parameter (both=Flase by default) to the extrude method
which allows to symmetrically extrude with respect to he current
workplane