### PR TITLE
String selector with logical operations

### DIFF
--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -569,7 +569,7 @@ def _makeExpressionGrammar(atom):
     #define operators
     and_op = Literal('and')
     or_op =  Literal('or')
-    delta_op =  Literal('exc') | Literal('except')
+    delta_op = oneOf(['exc','except'])
     not_op = Literal('not')
 
     def atom_callback(res):

--- a/cadquery/selectors.py
+++ b/cadquery/selectors.py
@@ -641,7 +641,7 @@ def _makeExpressionGrammar(atom):
     
     def delta_callback(res):
         items = res.asList()[0][::2]
-        reduce(SubtractSelector,items)
+        return reduce(SubtractSelector,items)
         
     def not_callback(res):
         right = res.asList()[0][1]

--- a/tests/TestCQSelectors.py
+++ b/tests/TestCQSelectors.py
@@ -453,6 +453,6 @@ class TestCQSelectors(BaseTest):
                        'bottom',
                        'not |(1,1,0) and >(0,0,1) or XY except >(1,1,1)[-1]',
                        '(not |(1,1,0) and >(0,0,1)) exc XY and (Z or X)']
-        #import pdb; pdb.set_trace()
+
         for e in expressions: gram.parseString(e,parseAll=True)
         

--- a/tests/TestCQSelectors.py
+++ b/tests/TestCQSelectors.py
@@ -453,6 +453,6 @@ class TestCQSelectors(BaseTest):
                        'bottom',
                        'not |(1,1,0) and >(0,0,1) or XY except >(1,1,1)[-1]',
                        '(not |(1,1,0) and >(0,0,1)) exc XY and (Z or X)']
-        
-        for e in expressions: gram.parseString(e)
+        #import pdb; pdb.set_trace()
+        for e in expressions: gram.parseString(e,parseAll=True)
         

--- a/tests/TestCQSelectors.py
+++ b/tests/TestCQSelectors.py
@@ -338,6 +338,10 @@ class TestCQSelectors(BaseTest):
         # test 'and' (intersection) operator
         el = c.edges(S('|X') & BS((-2,-2,0.1), (2,2,2))).vals()
         self.assertEqual(2, len(el))
+        
+        # test using extended string syntax
+        v = c.vertices(">X and >Y").vals()
+        self.assertEqual(2, len(v))
 
     def testSumSelector(self):
         c = CQ(makeUnitCube())
@@ -356,14 +360,10 @@ class TestCQSelectors(BaseTest):
         self.assertEqual(8, len(el))
         
         # test using extended string syntax
-        fl = c.faces(">Z | <Z").vals()
+        fl = c.faces(">Z or <Z").vals()
         self.assertEqual(2, len(fl))
-        el = c.edges("|X | |Y").vals()
+        el = c.edges("|X or |Y").vals()
         self.assertEqual(8, len(el))
-        
-        # test using extended string syntax
-        v = c.vertices(">X & >Y").vals()
-        self.assertEqual(2, len(v))
 
     def testSubtractSelector(self):
         c = CQ(makeUnitCube())
@@ -378,7 +378,7 @@ class TestCQSelectors(BaseTest):
         self.assertEqual(3, len(fl))
         
         # test using extended string syntax
-        fl = c.faces("#Z ^ >X").vals()
+        fl = c.faces("#Z exc >X").vals()
         self.assertEqual(3, len(fl))
 
     def testInverseSelector(self):
@@ -398,10 +398,17 @@ class TestCQSelectors(BaseTest):
         self.assertEqual(3, len(el))
         
         # test using extended string syntax
-        fl = c.faces('~>Z').vals()
+        fl = c.faces('not >Z').vals()
         self.assertEqual(5, len(fl))
-        el = c.faces('>Z').edges('~>X').vals()
+        el = c.faces('>Z').edges('not >X').vals()
         self.assertEqual(3, len(el))
+        
+    def testComplexStringSelector(self):
+        c = CQ(makeUnitCube())
+        
+        v = c.vertices('(>X and >Y) or (<X and <Y)').vals()
+        self.assertEqual(4, len(v))
+        
 
     def testFaceCount(self):
         c = CQ(makeUnitCube())
@@ -426,7 +433,7 @@ class TestCQSelectors(BaseTest):
         Test if reasonable string selector expressions parse without an error
         """
         
-        gram = selectors._makeGrammar()
+        gram = selectors._expression_grammar
 
         expressions = ['+X ',
                        '-Y',
@@ -443,7 +450,9 @@ class TestCQSelectors(BaseTest):
                        'left',
                        'right',
                        'top',
-                       'bottom']
+                       'bottom',
+                       'not |(1,1,0) and >(0,0,1) or XY except >(1,1,1)[-1]',
+                       '(not |(1,1,0) and >(0,0,1)) exc XY and (Z or X)']
         
         for e in expressions: gram.parseString(e)
         

--- a/tests/TestCQSelectors.py
+++ b/tests/TestCQSelectors.py
@@ -354,6 +354,16 @@ class TestCQSelectors(BaseTest):
         self.assertEqual(2, len(fl))
         el = c.edges(S("|X") + S("|Y")).vals()
         self.assertEqual(8, len(el))
+        
+        # test using extended string syntax
+        fl = c.faces(">Z | <Z").vals()
+        self.assertEqual(2, len(fl))
+        el = c.edges("|X | |Y").vals()
+        self.assertEqual(8, len(el))
+        
+        # test using extended string syntax
+        v = c.vertices(">X & >Y").vals()
+        self.assertEqual(2, len(v))
 
     def testSubtractSelector(self):
         c = CQ(makeUnitCube())
@@ -365,6 +375,10 @@ class TestCQSelectors(BaseTest):
 
         # test the subtract operator
         fl = c.faces(S("#Z") - S(">X")).vals()
+        self.assertEqual(3, len(fl))
+        
+        # test using extended string syntax
+        fl = c.faces("#Z ^ >X").vals()
         self.assertEqual(3, len(fl))
 
     def testInverseSelector(self):
@@ -381,6 +395,12 @@ class TestCQSelectors(BaseTest):
         fl = c.faces(-S('>Z')).vals()
         self.assertEqual(5, len(fl))
         el = c.faces('>Z').edges(-S('>X')).vals()
+        self.assertEqual(3, len(el))
+        
+        # test using extended string syntax
+        fl = c.faces('~>Z').vals()
+        self.assertEqual(5, len(fl))
+        el = c.faces('>Z').edges('~>X').vals()
         self.assertEqual(3, len(el))
 
     def testFaceCount(self):


### PR DESCRIPTION
This is WIP, do not merge yet.

New functionality still needs to be verified.

@dcowden  @jmwright  @hyOzd  current grammar supports following constructions:

_~|(1,1,0) & >(0,0,1) | XY & >(1,1,1)[-1]
~<((1,1,0) & >(0,0,1)) | XY & (Z | X)_

I have two questions:

1. Is this readable, i.e. do you agree to use ~ & | - as the operators?
2. Should we support nesting, i.e.  _(Z & X) & (~(X | Y) & XY)_ ? At the moment it is in.
