### PR TITLE
Fix "NameError: global name 'Face' is not defined"

### DIFF
--- a/cadquery/__init__.py
+++ b/cadquery/__init__.py
@@ -13,7 +13,7 @@ from .cq import *
 
 __all__ = [
     'CQ','Workplane','plugins','selectors','Plane','BoundBox','Matrix','Vector','sortWiresByBuildOrder',
-    'Shape','Vertex','Edge','Wire','Solid','Shell','Compound','exporters', 'importers',
+    'Shape','Vertex','Edge','Wire','Face','Solid','Shell','Compound','exporters', 'importers',
     'NearestToPointSelector','ParallelDirSelector','DirectionSelector','PerpendicularDirSelector',
     'TypeSelector','DirectionMinMaxSelector','StringSyntaxSelector','Selector','plugins'
 ]


### PR DESCRIPTION
Fix "NameError: global name 'Face' is not defined", It appears that 'Face' class is missing from __all__ list in the __init__.py.