### PR TITLE
makeHeilx added arguments

### DIFF
--- a/cadquery/freecad_impl/shapes.py
+++ b/cadquery/freecad_impl/shapes.py
@@ -430,7 +430,7 @@ class Edge(Shape):
         else:
             #FreeCAD >= 0.17
             self.edgetypes[FreeCADPart.Line] = 'LINE'
-            
+
          # Helps identify this solid through the use of an ID
         self.label = ""
 
@@ -482,7 +482,7 @@ class Edge(Shape):
     @classmethod
     def makeCircle(cls, radius, pnt=(0, 0, 0), dir=(0, 0, 1), angle1=360.0, angle2=360):
         center = Vector(pnt)
-        normal = Vector(dir)        
+        normal = Vector(dir)
         return Edge(FreeCADPart.makeCircle(radius, center.wrapped, normal.wrapped, angle1, angle2))
 
     @classmethod
@@ -582,13 +582,18 @@ class Wire(Shape):
         return w
 
     @classmethod
-    def makeHelix(cls, pitch, height, radius, angle=360.0):
+    def makeHelix(cls, pitch, height, radius, angle=0, lefthand=False, heightstyle=False):
         """
-        Make a helix with a given pitch, height and radius
-        By default a cylindrical surface is used to create the helix. If
-        the fourth parameter is set (the apex given in degree) a conical surface is used instead'
+        Make a helix along +z axis
+        :param pitch: displacement of 1 turn measured along surface.
+        :param height: full length of helix surface (measured sraight along surface's face)
+        :param radius: starting radius of helix
+        :param angle: if > 0, conical surface is used instead of a cylindrical. (angle < 0 not supported)
+        :param lefthand: if True, helix direction is reversed
+        :param heightstyle: if True, pitch and height are measured parallel to z-axis
         """
-        return Wire(FreeCADPart.makeHelix(pitch, height, radius, angle))
+        # FreeCAD doc: https://www.freecadweb.org/wiki/Part_API (search for makeHelix)
+        return Wire(FreeCADPart.makeHelix(pitch, height, radius, angle, lefthand, heightstyle))
 
     def clean(self):
         """This method is not implemented yet."""

--- a/tests/TestCadObjects.py
+++ b/tests/TestCadObjects.py
@@ -1,6 +1,7 @@
 #system modules
 import sys
 import unittest
+from math import pi, sin, sqrt, radians
 from tests import BaseTest
 import FreeCAD
 import Part
@@ -99,6 +100,45 @@ class TestCadObjects(BaseTest):
     def testVertices(self):
         e = Shape.cast(Part.makeLine((0, 0, 0), (1, 1, 0)))
         self.assertEquals(2, len(e.Vertices()))
+
+    def testWireMakeHelixDefault(self):
+        (pitch, height, radius) = (1., 5., 2.)
+        wire = Wire.makeHelix(pitch=pitch, height=height, radius=radius)
+
+        edge = wire.Edges()[0]
+        # Assert: helix length is correct
+        # expectation, default is a cylindrical helix
+        helix_horiz = (((2 * pi) * radius) * (height / pitch))
+        helix_vert = height
+        self.assertAlmostEqual(edge.Length(), sqrt(helix_horiz**2 + helix_vert**2), 4)
+
+        # Assert: bounding box is accurate
+        #   mainly checking that helix is in the positive Z direction.
+        #   not happy with the accuracy of BoundingBox (see places=2 below), but that's out of cadquery's scope
+        bb = edge.BoundingBox()
+        self.assertTupleAlmostEquals((bb.xmin, bb.xmax), (-radius, radius), 2)
+        self.assertTupleAlmostEquals((bb.ymin, bb.ymax), (-radius, radius), 2)
+        self.assertTupleAlmostEquals((bb.zmin, bb.zmax), (0, height), 3)
+
+    def testWireMakeHelixConical(self):
+        # helix is an upside-down cone
+        #   - beginning with a radius of `radius`
+        #   - ending with a radius of `radius + height*sin(30)`
+        (pitch, height, radius, angle) = (0.1, 5., 2., 30.)
+        wire = Wire.makeHelix(
+            pitch=pitch, height=height, radius=radius,
+            angle=angle, lefthand=True, heightstyle=True,
+        )  # left hand, just for goood measure
+
+        edge = wire.Edges()[0]
+        # Assert: bounding box is accurate
+        # note: small pitch increases accuracy of bounding box, but it's still atrocious
+        bb = edge.BoundingBox()
+        end_radius = radius + height * sin(radians(angle))
+        self.assertTupleAlmostEquals((bb.xmin, bb.xmax), (-end_radius, end_radius), 0)
+        self.assertTupleAlmostEquals((bb.ymin, bb.ymax), (-end_radius, end_radius), 0)
+        self.assertTupleAlmostEquals((bb.zmin, bb.zmax), (0, height), 3)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -47,7 +47,7 @@ def toTuple(v):
 
 class BaseTest(unittest.TestCase):
 
-    def assertTupleAlmostEquals(self, expected, actual, places):
+    def assertTupleAlmostEquals(self, expected, actual, places=7):
         for i, j in zip(actual, expected):
             self.assertAlmostEquals(i, j, places)
 


### PR DESCRIPTION
Added arguments to `cadquery.Wire.makeHelix`
**bugfixes**
* default angle doesn't raise exception

**Improvements**
* can make reverse direction of helix ("left-handed")
* can change height style to measure along z-axis instead of along surface (only effects a conical helix)
