### PR TITLE
logging

### DIFF
--- a/cadquery/__init__.py
+++ b/cadquery/__init__.py
@@ -1,6 +1,3 @@
-import sys
-import logging
-
 #these items point to the freecad implementation
 from .freecad_impl.geom import Plane,BoundBox,Vector,Matrix,sortWiresByBuildOrder
 from .freecad_impl.shapes import Shape,Vertex,Edge,Face,Wire,Solid,Shell,Compound
@@ -13,76 +10,16 @@ from .freecad_impl import importers
 from .selectors import *
 from .cq import *
 
+# logging
+from .logs import logging_enable, logging_disable
+
 
 __all__ = [
     'CQ','Workplane','plugins','selectors','Plane','BoundBox','Matrix','Vector','sortWiresByBuildOrder',
     'Shape','Vertex','Edge','Wire','Face','Solid','Shell','Compound','exporters', 'importers',
     'NearestToPointSelector','ParallelDirSelector','DirectionSelector','PerpendicularDirSelector',
-    'TypeSelector','DirectionMinMaxSelector','StringSyntaxSelector','Selector','plugins'
+    'TypeSelector','DirectionMinMaxSelector','StringSyntaxSelector','Selector','plugins',
+    'logging_enable', 'logging_disable',
 ]
 
 __version__ = "1.0.0"
-
-import sys
-import logging
-
-# --- Initialize logging
-# any script can log to FreeCAD console with:
-#
-#   >>> import cadquery
-#   >>> import logging
-#   >>> log = logging.getLogger(__name__)
-#   >>> log.debug("detailed info, not normally displayed")
-#   >>> log.info("some information")
-#   some information
-#   >>> log.warning("some warning text")  # orange text
-#   some warning text
-#   >>> log.error("an error message")  # red text
-#   an error message
-#
-# debug logging can be enabled in your script with:
-# 
-#   >>> import logging
-#   >>> logging.getLogger().setLevel(logging.DEBUG)
-#   >>> log = logging.getLogger(__name__)
-#   >>> log.debug("debug logs will now be displayed")
-#   debug logs will now be displayed
-#
-root_logger = logging.getLogger()
-root_logger.setLevel(logging.INFO)
-
-# FreeCAD Logging Handler
-class FreeCADConsoleHandler(logging.Handler):
-    # Custom flag to identify loggers writing to the FreeCAD.Console
-    # why?, This same implementation may be coppied to freecad modules, this helps
-    # avoid duplicate logging... futureproofing ftw
-    freecad_console = True
-
-    def emit(self, record):
-        log_text = self.format(record) + "\n"
-        if record.levelno >= logging.ERROR:
-            FreeCAD.Console.PrintError(log_text)
-        elif record.levelno >= logging.WARNING:
-            FreeCAD.Console.PrintWarning(log_text)
-        else:
-            FreeCAD.Console.PrintMessage(log_text)
-
-try:
-    import FreeCAD
-    FreeCAD.Console  # will raise exception if not available
-
-    if not any(getattr(h, 'freecad_console', False) for h in root_logger.handlers):
-        # avoid duplicate logging
-        freecad_handler = FreeCADConsoleHandler()
-        freecad_handler.setLevel(logging.DEBUG)
-        formatter = logging.Formatter('%(message)s')
-        freecad_handler.setFormatter(formatter)
-        root_logger.addHandler(freecad_handler)
-
-except Exception as e:
-    # Fall back to STDOUT output (better than nothing)
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%(message)s')
-    stdout_handler.setFormatter(formatter)
-    root_logger.addHandler(stdout_handler)

--- a/cadquery/__init__.py
+++ b/cadquery/__init__.py
@@ -1,3 +1,6 @@
+import sys
+import logging
+
 #these items point to the freecad implementation
 from .freecad_impl.geom import Plane,BoundBox,Vector,Matrix,sortWiresByBuildOrder
 from .freecad_impl.shapes import Shape,Vertex,Edge,Face,Wire,Solid,Shell,Compound
@@ -19,3 +22,67 @@ __all__ = [
 ]
 
 __version__ = "1.0.0"
+
+import sys
+import logging
+
+# --- Initialize logging
+# any script can log to FreeCAD console with:
+#
+#   >>> import cadquery
+#   >>> import logging
+#   >>> log = logging.getLogger(__name__)
+#   >>> log.debug("detailed info, not normally displayed")
+#   >>> log.info("some information")
+#   some information
+#   >>> log.warning("some warning text")  # orange text
+#   some warning text
+#   >>> log.error("an error message")  # red text
+#   an error message
+#
+# debug logging can be enabled in your script with:
+# 
+#   >>> import logging
+#   >>> logging.getLogger().setLevel(logging.DEBUG)
+#   >>> log = logging.getLogger(__name__)
+#   >>> log.debug("debug logs will now be displayed")
+#   debug logs will now be displayed
+#
+root_logger = logging.getLogger()
+root_logger.setLevel(logging.INFO)
+
+# FreeCAD Logging Handler
+class FreeCADConsoleHandler(logging.Handler):
+    # Custom flag to identify loggers writing to the FreeCAD.Console
+    # why?, This same implementation may be coppied to freecad modules, this helps
+    # avoid duplicate logging... futureproofing ftw
+    freecad_console = True
+
+    def emit(self, record):
+        log_text = self.format(record) + "\n"
+        if record.levelno >= logging.ERROR:
+            FreeCAD.Console.PrintError(log_text)
+        elif record.levelno >= logging.WARNING:
+            FreeCAD.Console.PrintWarning(log_text)
+        else:
+            FreeCAD.Console.PrintMessage(log_text)
+
+try:
+    import FreeCAD
+    FreeCAD.Console  # will raise exception if not available
+
+    if not any(getattr(h, 'freecad_console', False) for h in root_logger.handlers):
+        # avoid duplicate logging
+        freecad_handler = FreeCADConsoleHandler()
+        freecad_handler.setLevel(logging.DEBUG)
+        formatter = logging.Formatter('%(message)s')
+        freecad_handler.setFormatter(formatter)
+        root_logger.addHandler(freecad_handler)
+
+except Exception as e:
+    # Fall back to STDOUT output (better than nothing)
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(message)s')
+    stdout_handler.setFormatter(formatter)
+    root_logger.addHandler(stdout_handler)

--- a/cadquery/__init__.py
+++ b/cadquery/__init__.py
@@ -10,16 +10,12 @@ from .freecad_impl import importers
 from .selectors import *
 from .cq import *
 
-# logging
-from .logs import logging_enable, logging_disable
-
 
 __all__ = [
     'CQ','Workplane','plugins','selectors','Plane','BoundBox','Matrix','Vector','sortWiresByBuildOrder',
     'Shape','Vertex','Edge','Wire','Face','Solid','Shell','Compound','exporters', 'importers',
     'NearestToPointSelector','ParallelDirSelector','DirectionSelector','PerpendicularDirSelector',
     'TypeSelector','DirectionMinMaxSelector','StringSyntaxSelector','Selector','plugins',
-    'logging_enable', 'logging_disable',
 ]
 
 __version__ = "1.0.0"

--- a/cadquery/freecad_impl/__init__.py
+++ b/cadquery/freecad_impl/__init__.py
@@ -105,3 +105,6 @@ except ImportError:
     path = _fc_path()
     sys.path.insert(0, path)
     import FreeCAD
+
+# logging
+import console_logging

--- a/cadquery/freecad_impl/console_logging.py
+++ b/cadquery/freecad_impl/console_logging.py
@@ -1,7 +1,6 @@
 import sys
 import logging
 
-import freecad_impl  # appends FreeCAD path
 import FreeCAD
 
 # Logging Handler
@@ -32,7 +31,7 @@ class FreeCADConsoleHandler(logging.Handler):
             FreeCAD.Console.PrintMessage(log_text)
 
 
-def logging_enable(level=None, format="%(message)s"):
+def enable(level=None, format="%(message)s"):
     """
     Enable python builtin logging, and output it somewhere you can see.
      - FreeCAD Console, or
@@ -41,7 +40,7 @@ def logging_enable(level=None, format="%(message)s"):
     Any script can log to FreeCAD console with:
 
         >>> import cadquery
-        >>> cadquery.logging_enable()
+        >>> cadquery.freecad_impl.console_logging.enable()
         >>> import logging
         >>> log = logging.getLogger(__name__)
         >>> log.debug("detailed info, not normally displayed")
@@ -57,7 +56,7 @@ def logging_enable(level=None, format="%(message)s"):
 
         >>> import cadquery
         >>> import logging
-        >>> cadquery.logging_enable(logging.DEBUG)
+        >>> cadquery.freecad_impl.console_logging.enable(logging.DEBUG)
         >>> log = logging.getLogger(__name__)
         >>> log.debug("debug logs will now be displayed")
         debug logs will now be displayed
@@ -99,7 +98,7 @@ def logging_enable(level=None, format="%(message)s"):
     return _logging_handler
 
 
-def logging_disable():
+def disable():
     """
     Disables logging to FreeCAD console (or STDOUT).
     Note, logging may be enabled by another imported module, so this isn't a

--- a/cadquery/logs.py
+++ b/cadquery/logs.py
@@ -1,0 +1,112 @@
+import sys
+import logging
+
+import freecad_impl  # appends FreeCAD path
+import FreeCAD
+
+# Logging Handler
+#   Retain a reference to the logging handler so it may be removed on requeset.
+#   Also to prevent 2 handlers being added
+_logging_handler = None
+
+# FreeCAD Logging Handler
+class FreeCADConsoleHandler(logging.Handler):
+    """logging.Handler class to output to FreeCAD's console"""
+
+    def __init__(self, *args, **kwargs):
+        super(FreeCADConsoleHandler, self).__init__(*args, **kwargs)
+
+        # Test for expected print functions
+        # (just check they exist, if they don't an exception will be raised)
+        FreeCAD.Console.PrintMessage
+        FreeCAD.Console.PrintWarning
+        FreeCAD.Console.PrintError
+
+    def emit(self, record):
+        log_text = self.format(record) + "\n"
+        if record.levelno >= logging.ERROR:
+            FreeCAD.Console.PrintError(log_text)
+        elif record.levelno >= logging.WARNING:
+            FreeCAD.Console.PrintWarning(log_text)
+        else:
+            FreeCAD.Console.PrintMessage(log_text)
+
+
+def logging_enable(level=None, format="%(message)s"):
+    """
+    Enable python builtin logging, and output it somewhere you can see.
+     - FreeCAD Console, or
+     - STDOUT (if output to console fails, for whatever reason)
+
+    Any script can log to FreeCAD console with:
+
+        >>> import cadquery
+        >>> cadquery.logging_enable()
+        >>> import logging
+        >>> log = logging.getLogger(__name__)
+        >>> log.debug("detailed info, not normally displayed")
+        >>> log.info("some information")
+        some information
+        >>> log.warning("some warning text")  # orange text
+        some warning text
+        >>> log.error("an error message")  # red text
+        an error message
+
+    logging only needs to be enabled once, somewhere in your codebase.
+    debug logging level can be set with:
+
+        >>> import cadquery
+        >>> import logging
+        >>> cadquery.logging_enable(logging.DEBUG)
+        >>> log = logging.getLogger(__name__)
+        >>> log.debug("debug logs will now be displayed")
+        debug logs will now be displayed
+
+    :param level: logging level to display, one of logging.(DEBUG|INFO|WARNING|ERROR)
+    :param format: logging format to display (search for "python logging format" for details)
+    :return: the logging Handler instance in effect
+    """
+    global _logging_handler
+
+    # Set overall logging level (done even if handler has already been assigned)
+    root_logger = logging.getLogger()
+    if level is not None:
+        root_logger.setLevel(level)
+    elif _logging_handler is None:
+        # level is not specified, and ho handler has been added yet.
+        # assumption: user is enabling logging for the first time with no parameters.
+        # let's make it simple for them and default the level to logging.INFO
+        # (logging default level is logging.WARNING)
+        root_logger.setLevel(logging.INFO)
+
+    if _logging_handler is None:
+        # Determine which Handler class to use
+        try:
+            _logging_handler = FreeCADConsoleHandler()
+        except Exception as e:
+            raise
+            # Fall back to STDOUT output (better than nothing)
+            _logging_handler = logging.StreamHandler(sys.stdout)
+
+        # Configure and assign handler to root logger
+        _logging_handler.setLevel(logging.DEBUG)
+        root_logger.addHandler(_logging_handler)
+
+    # Set formatting (can be used to re-define logging format)
+    formatter = logging.Formatter(format)
+    _logging_handler.setFormatter(formatter)
+
+    return _logging_handler
+
+
+def logging_disable():
+    """
+    Disables logging to FreeCAD console (or STDOUT).
+    Note, logging may be enabled by another imported module, so this isn't a
+    guarentee; this function undoes logging_enable(), nothing more.
+    """
+    global _logging_handler
+    if _logging_handler:
+        root_logger = logging.getLogger()
+        root_logger.handlers.remove(_logging_handler)
+        _logging_handler = None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ Sphinx==1.3.2
 coverage
 coveralls
 pyparsing
+mock

--- a/runtests.py
+++ b/runtests.py
@@ -16,4 +16,5 @@ suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestCQSelectors.TestC
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestCadQuery.TestCadQuery))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestExporters.TestExporters))
 suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestImporters.TestImporters))
+suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TestLogging.TestLogging))
 unittest.TextTestRunner().run(suite)

--- a/tests/TestLogging.py
+++ b/tests/TestLogging.py
@@ -1,0 +1,101 @@
+import unittest
+import mock
+from copy import copy
+from tests import BaseTest
+
+import logging
+
+# Units under test
+import cadquery
+from cadquery.freecad_impl import console_logging
+
+
+class TestLogging(BaseTest):
+    def setUp(self):
+        # save root logger's state
+        root_logger = logging.getLogger()
+        self._initial_level = root_logger.level
+        self._initial_logging_handlers = copy(root_logger.handlers)
+
+    def tearDown(self):
+        # forcefully re-establish original log state
+        root_logger = logging.getLogger()
+        root_logger.level = self._initial_level
+        root_logger.handlers = self._initial_logging_handlers
+        # reset console_logging's global state
+        cadquery.freecad_impl.console_logging._logging_handler = None
+
+    @mock.patch('cadquery.freecad_impl.console_logging.FreeCAD')
+    def testConsoleMessage(self, mock_freecad):
+        console_logging.enable()
+        log = logging.getLogger('test')
+
+        log.info('foo')
+        mock_freecad.Console.PrintMessage.assert_called_once_with('foo\n')
+        mock_freecad.Console.PrintWarning.assert_not_called()
+        mock_freecad.Console.PrintError.assert_not_called()
+
+    @mock.patch('cadquery.freecad_impl.console_logging.FreeCAD')
+    def testConsoleWarning(self, mock_freecad):
+        console_logging.enable()
+        log = logging.getLogger('test')
+
+        log.warning('bar')
+        mock_freecad.Console.PrintMessage.assert_not_called()
+        mock_freecad.Console.PrintWarning.assert_called_once_with('bar\n')
+        mock_freecad.Console.PrintError.assert_not_called()
+
+    @mock.patch('cadquery.freecad_impl.console_logging.FreeCAD')
+    def testConsoleError(self, mock_freecad):
+        console_logging.enable()
+        log = logging.getLogger('test')
+
+        log.error('roo')
+        mock_freecad.Console.PrintMessage.assert_not_called()
+        mock_freecad.Console.PrintWarning.assert_not_called()
+        mock_freecad.Console.PrintError.assert_called_once_with('roo\n')
+
+    @mock.patch('cadquery.freecad_impl.console_logging.FreeCAD')
+    def testConsoleDebugOffDefault(self, mock_freecad):
+        console_logging.enable()
+        log = logging.getLogger('test')
+
+        log.debug('no show')
+        mock_freecad.Console.PrintMessage.assert_not_called()
+        mock_freecad.Console.PrintWarning.assert_not_called()
+        mock_freecad.Console.PrintError.assert_not_called()
+
+    @mock.patch('cadquery.freecad_impl.console_logging.FreeCAD')
+    def testConsoleSetLevelDebug(self, mock_freecad):
+        console_logging.enable(level=logging.DEBUG)
+        log = logging.getLogger('test')
+
+        log.debug('now showing')
+        mock_freecad.Console.PrintMessage.assert_called_once_with('now showing\n')
+
+    @mock.patch('cadquery.freecad_impl.console_logging.FreeCAD')
+    def testConsoleSetLevelWarning(self, mock_freecad):
+        console_logging.enable(level=logging.WARNING)
+        log = logging.getLogger('test')
+
+        log.info('no show')
+        log.warning('be warned')
+        mock_freecad.Console.PrintMessage.assert_not_called()
+        mock_freecad.Console.PrintWarning.assert_called_once_with('be warned\n')
+
+    @mock.patch('cadquery.freecad_impl.console_logging.FreeCAD')
+    def testConsoleLogFormat(self, mock_freecad):
+        console_logging.enable(format=">> %(message)s <<")
+        log = logging.getLogger('test')
+
+        log.info('behold brackets!')
+        mock_freecad.Console.PrintMessage.assert_called_once_with('>> behold brackets! <<\n')
+
+    @mock.patch('cadquery.freecad_impl.console_logging.FreeCAD')
+    def testConsoleEnableDisable(self, mock_freecad):
+        console_logging.enable()
+        console_logging.disable()
+        log = logging.getLogger('test')
+
+        log.error('nope, disabled')
+        mock_freecad.Console.PrintError.assert_not_called()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -52,3 +52,14 @@ class BaseTest(unittest.TestCase):
             self.assertAlmostEquals(i, j, places)
 
 __all__ = ['TestCadObjects', 'TestCadQuery', 'TestCQSelectors', 'TestWorkplanes', 'TestExporters', 'TestCQSelectors', 'TestImporters','TestCQGI']
+__all__ = [
+    'TestCQGI',
+    'TestCQSelectors',
+    'TestCQSelectors',
+    'TestCadObjects',
+    'TestCadQuery',
+    'TestExporters',
+    'TestImporters',
+    'TestLogging',
+    'TestWorkplanes',
+]


### PR DESCRIPTION
Any script can log to FreeCAD console with:

```python
>>> import cadquery
>>> import logging
>>> log = logging.getLogger(__name__)
>>> log.debug("detailed info, not normally displayed")
>>> log.info("some information")
some information
>>> log.warning("some warning text")  # orange text
some warning text
>>> log.error("an error message")  # red text
an error message
```

debug logging can be enabled in any script with:

```python
>>> import logging
>>> logging.getLogger().setLevel(logging.DEBUG)
>>> log = logging.getLogger(__name__)
>>> log.debug("debug logs will now be displayed")
debug logs will now be displayed
```