### PR TITLE
WIP: Docker cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER <dave.cowden@gmail.com>
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
-EVN CQ_HOME=/opt/cadquery
+ENV CQ_HOME=/opt/cadquery
 
 #from continuum: https://hub.docker.com/r/continuumio/anaconda/~/dockerfile/
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
@@ -31,6 +31,9 @@ RUN add-apt-repository -y ppa:freecad-maintainers/freecad-stable && \
     apt-get update && apt-get install -y freecad
 
 RUN mkdir -p $CQ_HOME
+RUN mkdir -p $CQ_HOME/build_data
+VOLUME $CQ_HOME/build_data
+
 COPY requirements-dev.txt  runtests.py  cq_cmd.py cq_cmd.sh setup.py  README.md MANIFEST setup.cfg $CQ_HOME/
 COPY cadquery $CQ_HOME/cadquery
 COPY examples $CQ_HOME/examples

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER <dave.cowden@gmail.com>
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
-
+EVN CQ_HOME=/opt/cadquery
 
 #from continuum: https://hub.docker.com/r/continuumio/anaconda/~/dockerfile/
 RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
@@ -30,16 +30,16 @@ RUN apt-get install -y software-properties-common
 RUN add-apt-repository -y ppa:freecad-maintainers/freecad-stable && \
     apt-get update && apt-get install -y freecad
 
-RUN mkdir -p /opt/cadquery
-COPY requirements-dev.txt  runtests.py  cq_cmd.py cq_cmd.sh setup.py  README.md MANIFEST setup.cfg /opt/cadquery/
-COPY cadquery /opt/cadquery/cadquery
-COPY examples /opt/cadquery/examples
-COPY tests /opt/cadquery/tests
+RUN mkdir -p $CQ_HOME
+COPY requirements-dev.txt  runtests.py  cq_cmd.py cq_cmd.sh setup.py  README.md MANIFEST setup.cfg $CQ_HOME/
+COPY cadquery $CQ_HOME/cadquery
+COPY examples $CQ_HOME/examples
+COPY tests $CQ_HOME/tests
 
 
 RUN pip install -r /opt/cadquery/requirements-dev.txt
-RUN cd /opt/cadquery && python ./setup.py install
-RUN chmod +x /opt/cadquery/cq_cmd.sh
+RUN cd $CQ_HOME && python ./setup.py install
+RUN chmod +x $CQ_HOME/cq_cmd.sh
 RUN useradd -ms /bin/bash cq
 USER cq
 WORKDIR /home/cq

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:16.04
+
+MAINTAINER <dave.cowden@gmail.com>
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+
+
+#from continuum: https://hub.docker.com/r/continuumio/anaconda/~/dockerfile/
+RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
+    libglib2.0-0 libxext6 libsm6 libxrender1 \
+    git mercurial subversion
+
+RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet https://repo.continuum.io/archive/Anaconda2-5.0.0-Linux-x86_64.sh -O ~/anaconda.sh && \
+    /bin/bash ~/anaconda.sh -b -p /opt/conda && \
+    rm ~/anaconda.sh
+
+RUN apt-get install -y curl grep sed dpkg  && \
+    TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
+    curl -L "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" > tini.deb && \
+    dpkg -i tini.deb && \
+    rm tini.deb && \
+    apt-get clean
+
+ENV PATH /opt/conda/bin:$PATH
+
+RUN apt-get install -y software-properties-common
+
+RUN add-apt-repository -y ppa:freecad-maintainers/freecad-stable && \
+    apt-get update && apt-get install -y freecad
+
+RUN mkdir -p /opt/cadquery
+COPY requirements-dev.txt  runtests.py  cq_cmd.py cq_cmd.sh setup.py  README.md MANIFEST setup.cfg /opt/cadquery/
+COPY cadquery /opt/cadquery/cadquery
+COPY examples /opt/cadquery/examples
+COPY tests /opt/cadquery/tests
+
+
+RUN pip install -r /opt/cadquery/requirements-dev.txt
+RUN cd /opt/cadquery && python ./setup.py install
+RUN chmod +x /opt/cadquery/cq_cmd.sh
+RUN useradd -ms /bin/bash cq
+USER cq
+WORKDIR /home/cq
+
+ENTRYPOINT [ "/opt/cadquery/cq_cmd.sh" ]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,37 @@ CadQuery has several goals:
 
 Using CadQuery, you can write short, simple scripts that produce high quality CAD models.  It is easy to make many different objects using a single script that can be customized.
 
+Getting Started with the docker image
+=======================================
+The caduery docker image (https://hub.docker.com/r/dcowden/cadquery/)  includes cadquery and all of its dependencies. It can be used to run cadquery scripts without any installation required ( other than docker, of course)
+
+Examples:
+
+Display the Documentation::
+
+     docker run dcowden/cadquery:latest
+
+Build a local model using stdin/stdout::
+
+     cat Ex001_Simple_Block.py | docker run -i dcowden/cadquery:latest build --in_spec stdin --format STEP --out_spec stdout
+
+     *... STEP output on the console*
+
+Build local models and output to the same directory::
+
+     *sudo docker run -v $PWD:/home/cq -i dcowden/cadquery:latest build --in_spec Ex001_Simple_Block.py --format STEP*
+     INFO: Reading from file 'Ex001_Simple_Block.py'
+     INFO: Parsed Script 'Ex001_Simple_Block.py'.
+     INFO: This script provides parameters length,thickness,height, which can be customized at build time.
+     INFO: The script will run with default variable values
+     INFO: use --param_file to provide a json file that contains values to override the defaults
+     INFO: Output Format is 'STEP'. Use --output-format to change it.
+     INFO: Output Path is './cqobject-%(counter)d.%(format)s'. Use --out_spec to change it.
+     INFO: Script Generated 1 result Objects
+     INFO: Writing STEP Output to './cqobject-1.STEP'
+
+
+
 Full Documentation
 ============================
 You can find the full cadquery documentation at http://dcowden.github.io/cadquery
@@ -189,7 +220,7 @@ You can use CadQuery inside of FreeCAD. There's an excellent plugin module here 
 Work is underway on a stand-alone gui here:  https://github.com/jmwright/cadquery-gui
 
 ### ParametricParts.com
-If you are impatient and want to see a working example with no installation, have a look at this lego brick example http://parametricparts.com/parts/vqb5dy69/. 
+If you are impatient and want to see a working example with no installation, have a look at this lego brick example http://parametricparts.com/parts/vqb5dy69/.
 
 The script that generates the model is on the 'modelscript' tab.
 
@@ -247,7 +278,7 @@ Roadmap/Future Work
 =======================
 
 Work has begun on Cadquery 2.0, which will feature:
- 
+
    1. Feature trees, for more powerful selection
    2. Direct use of OpenCascade Community Edition(OCE), so that it is no longer required to install FreeCAD
    3. https://github.com/jmwright/cadquery-gui, which will allow visualization of workplanes  
@@ -269,4 +300,3 @@ If you are familiar with how jQuery, you will probably recognize several jQuery 
 *
 * Ability to use the library along side other python libraries
 * Clear and complete documentation, with plenty of samples.
-

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Build a local model using stdin/stdout::
 
      cat Ex001_Simple_Block.py | docker run -i dcowden/cadquery:latest build --in_spec stdin --format STEP --out_spec stdout
 
-     *... STEP output on the console*
+     ... STEP output on the console
 
 Build local models and output to the same directory::
 
-     *sudo docker run -v $PWD:/home/cq -i dcowden/cadquery:latest build --in_spec Ex001_Simple_Block.py --format STEP*
+     docker run -v $PWD:/home/cq -i dcowden/cadquery:latest build --in_spec Ex001_Simple_Block.py --format STEP
      INFO: Reading from file 'Ex001_Simple_Block.py'
      INFO: Parsed Script 'Ex001_Simple_Block.py'.
      INFO: This script provides parameters length,thickness,height, which can be customized at build time.

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+#builds and tests the docker image
+docker build -t dcowden/cadquery .
+
+# set up tests
+CQ_TEST_DIR=/tmp/cq_docker-test
+mkdir -p $CQ_TEST_DIR
+rm -rf $CQ_TEST_DIR/*.*
+cp examples/FreeCAD/Ex001_Simple_Block.py $CQ_TEST_DIR
+
+
+fail_test(  ){
+   "Test Failed."
+}
+
+echo "Running Tests..."
+echo "No arguments prints documentation..."
+docker run  dcowden/cadquery | grep "CadQuery Docker Image" || fail_test
+echo "OK"
+
+echo "Std in and stdout..."
+cat $CQ_TEST_DIR/Ex001_Simple_Block.py | docker run -i  dcowden/cadquery build --in_spec stdin --out_spec stdout | grep "ISO-10303-21" || fail_test
+echo "OK"
+
+echo "Mount a directory and produce output..."
+docker run -i -v $CQ_TEST_DIR:/home/cq  dcowden/cadquery build --in_spec Ex001_Simple_Block.py --format STEP
+ls $CQ_TEST_DIR | grep "cqobject-1.STEP" || fail_test
+echo "OK"
+
+echo "Future Server EntryPoint"
+docker run -i dcowden/cadquery runserver | grep "Future CadQuery Server" || fail_test
+echo "OK"

--- a/cadquery/freecad_impl/__init__.py
+++ b/cadquery/freecad_impl/__init__.py
@@ -20,6 +20,39 @@ import os
 import sys
 
 
+#FreeCAD has crudified the stdout stream with a bunch of STEP output
+#garbage
+#this cleans it up
+#so it is possible to use stdout for object output
+class suppress_stdout_stderr(object):
+    '''
+    A context manager for doing a "deep suppression" of stdout and stderr in
+    Python, i.e. will suppress all print, even if the print originates in a
+    compiled C/Fortran sub-function.
+       This will not suppress raised exceptions, since exceptions are printed
+    to stderr just before a script exits, and after the context manager has
+    exited (at least, I think that is why it lets exceptions through).
+
+    '''
+    def __init__(self):
+        # Open a pair of null files
+        self.null_fds =  [os.open(os.devnull,os.O_RDWR) for x in range(2)]
+        # Save the actual stdout (1) and stderr (2) file descriptors.
+        self.save_fds = [os.dup(1), os.dup(2)]
+
+    def __enter__(self):
+        # Assign the null pointers to stdout and stderr.
+        os.dup2(self.null_fds[0],1)
+        os.dup2(self.null_fds[1],2)
+
+    def __exit__(self, *_):
+        # Re-assign the real stdout/stderr back to (1) and (2)
+        os.dup2(self.save_fds[0],1)
+        os.dup2(self.save_fds[1],2)
+        # Close all file descriptors
+        for fd in self.null_fds + self.save_fds:
+            os.close(fd)
+
 def _fc_path():
     """Find FreeCAD"""
     # Look for FREECAD_LIB env variable
@@ -99,12 +132,13 @@ def _fc_path():
 
 
 # Make sure that the correct FreeCAD path shows up in Python's system path
-try:
-    import FreeCAD
-except ImportError:
-    path = _fc_path()
-    sys.path.insert(0, path)
-    import FreeCAD
+with suppress_stdout_stderr():
+    try:
+        import FreeCAD
+    except ImportError:
+        path = _fc_path()
+        sys.path.insert(0, path)
+        import FreeCAD
 
 # logging
 import console_logging

--- a/cq_cmd.py
+++ b/cq_cmd.py
@@ -11,38 +11,8 @@ import sys,os
 
 
 
-#FreeCAD has crudified the stdout stream with a bunch of STEP output
-#garbage
-#this cleans it up
-#so it is possible to use stdout for object output
-class suppress_stdout_stderr(object):
-    '''
-    A context manager for doing a "deep suppression" of stdout and stderr in
-    Python, i.e. will suppress all print, even if the print originates in a
-    compiled C/Fortran sub-function.
-       This will not suppress raised exceptions, since exceptions are printed
-    to stderr just before a script exits, and after the context manager has
-    exited (at least, I think that is why it lets exceptions through).
 
-    '''
-    def __init__(self):
-        # Open a pair of null files
-        self.null_fds =  [os.open(os.devnull,os.O_RDWR) for x in range(2)]
-        # Save the actual stdout (1) and stderr (2) file descriptors.
-        self.save_fds = [os.dup(1), os.dup(2)]
 
-    def __enter__(self):
-        # Assign the null pointers to stdout and stderr.
-        os.dup2(self.null_fds[0],1)
-        os.dup2(self.null_fds[1],2)
-
-    def __exit__(self, *_):
-        # Re-assign the real stdout/stderr back to (1) and (2)
-        os.dup2(self.save_fds[0],1)
-        os.dup2(self.save_fds[1],2)
-        # Close all file descriptors
-        for fd in self.null_fds + self.save_fds:
-            os.close(fd)
 
 
 from cadquery import cqgi,exporters
@@ -214,6 +184,7 @@ Each object created by the script is written the supplied output directory.
 Filename pattern to use when creating output files.
 The sequential file number and the format are available.
 Default: cqobject-%%(counter)d.%%(format)s
+Use stdout to write to stdout ( can't be used for multiple results though)
     """
     parser = argparse.ArgumentParser(description=desc)
     parser.add_argument("--format", action="store",default="STEP",help="Output Object format (TJS|STEP|STL|SVG)")

--- a/cq_cmd.py
+++ b/cq_cmd.py
@@ -1,0 +1,174 @@
+#
+# cadquery command line interface
+# usage: cq_cmd  [-h] [--param-file inputfile ] [--format STEP|STL ] [--output filename] filename
+# if input file contains multiple inputs, multiple outputs are created
+# if no input filename is provided, stdin is read instead
+# if no output filename is provided, output goes to stdout
+# default output format is STEP
+#
+from __future__ import print_function
+from cadquery import cqgi,exporters
+import argparse
+import sys
+import os.path
+import json
+
+
+class ErrorCodes(object):
+    SCRIPT_ERROR=2
+    UNKNOWN_ERROR=3
+    INVALID_OUTPUT_DESTINATION=4
+    INVALID_OUTPUT_FORMAT=5
+    INVALID_INPUT=6
+    MULTIPLE_RESULTS=7
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+def error(msg,exit_code=1):
+    eprint("ERROR %d: %s" %( exit_code,  msg))
+    sys.exit(exit_code)
+
+def warning(msg):
+    eprint("WARNING: %s" % msg)
+
+def info(msg):
+    eprint("INFO: %s" % msg)
+
+def make_output_filename(counter,format_pattern, shape_format):
+    return format_pattern % ({ "counter": counter,"format": shape_format } )
+
+def read_param_file(file_name):
+    if file_name is not None:
+        p = read_file_as_string(file_name)
+        if p is not None:
+            info("Build Parameters: %s" % str(p))
+            return json.parse(p)
+
+    return {}
+def read_file_as_string(file_name):
+    if os.path.isfile(file_name):
+        f = open(file_name)
+        s = f.read()
+        f.close()
+        return s
+    else:
+        return None
+
+def read_input_script(file_name):
+    if file_name:
+        s = read_file_as_string(file_name)
+        if s is None:
+            error("%s does not appear to be a readable file." % file_name,ErrorCodes.INVALID_INPUT)
+        else:
+            return s
+    else:
+        s = sys.stdin.read()
+        return s
+
+def check_input_format(input_format):
+    valid_types = [exporters.ExportTypes.TJS,exporters.ExportTypes.AMF,
+        exporters.ExportTypes.STEP,exporters.ExportTypes.STL,exporters.ExportTypes.TJS ]
+    if input_format not in valid_types:
+        error("Invalid Input format '%s'. Valid values: %s" % ( input_format, str(valid_types)) ,
+        ErrorCodes.INVALID_OUTPUT_FORMAT)
+
+def export_to_file(filename, shape, shape_format):
+    info("Writing %s Output to '%s'" % (shape_format, filename))
+    s = open(filename,'w')
+    exporters.exportShape(shape,shape_format,s)
+    s.flush()
+    s.close()
+
+def output_single_result(user_output_filename, shape_format,shape_result,file_format_pattern):
+    output_filename = None
+    if user_output_filename is None:
+        output_filename = make_output_filename(1,file_format_pattern,shape_format)
+    elif os.path.isfile(user_output_filename):
+        output_filename = user_output_filename
+    elif os.path.isdir(user_output_filename):
+        output_filename = os.path.join(user_output_filename, make_output_filename(1,file_format_pattern,shape_format))
+    else:
+        error("Can't write to destination %s'" % user_output_filename, ErrorCodes.INVALID_OUTPUT_DESTINATION)
+    export_to_file(output_filename,shape_result.shape,shape_format)
+
+def output_multiple_results(output_filename,shape_format, result_list,file_format_pattern):
+
+    if output_filename is None or not os.path.isdir(output_filename):
+        info("No output destination provided. using current directory.")
+        output_filename = "."
+    counter = 1
+    for shape_result in result_list:
+        fname = make_output_filename(counter,file_format_pattern,shape_format)
+        outfile_name = os.path.join(output_filename, fname)
+        export_to_file(outfile_name,shape_result.shape,shape_format)
+        counter += 1
+
+def process_parameters(script_param_file, script_params):
+    if len(script_params)> 0:
+        parameter_names = ",".join(script_params.keys())
+        info("This script provides parameters %s, which can be customized at build time." % parameter_names)
+    else:
+        info("This script provides no customizable build parameters.")
+
+    params = read_param_file(script_param_file)
+    if len(params) > 0:
+        info("User Supplied Parameter Values ( Override Model Defaults):")
+        info(str(params))
+    else:
+        info("The script will run with default variable values")
+        info("use --param_file to provide a json file that contains values to override the defaults")
+    return params
+
+def run(args):
+
+
+    input_script = read_input_script(args.in_file)
+    script_name = 'stdin' if args.in_file is None else args.in_file
+    cq_model = cqgi.parse(input_script)
+    info("Parsed Script '%s'." % script_name)
+
+    params = process_parameters(args.param_file,cq_model.metadata.parameters)
+
+    output_format = 'STEP'
+    if args.output_format:
+        check_input_format(args.output_format)
+        output_format = args.output_format
+
+    info("Output Format is '%s'. Use --output-format to change it." % output_format)
+    info("Output Directory is '%s'. Use --out_dir to change it." % args.out_dir)
+    info("Output File Pattern is '%s'. Use --filename_pattern to change it." % args.filename_pattern)
+
+    build_result = cq_model.build(build_parameters=params)
+    if build_result.success:
+        result_list = build_result.results
+        info("Script Generated %d result Objects" % len(result_list))
+        if len(result_list) > 1:
+            output_multiple_results(args.out_dir, output_format, result_list,args.filename_pattern)
+        else:
+            output_single_result(args.out_dir,output_format,result_list[0],args.filename_pattern)
+    else:
+        error("Script Error: '%s'" % build_result.exception,ErrorCodes.SCRIPT_ERROR)
+
+
+if __name__=='__main__':
+
+    desc="""
+CQ CMD. Runs a cadquery python file, and produces a 3d object.
+A script can be provided as a file or as standard input.
+Each object created by the script is written the supplied output directory.
+    """
+    filename_pattern_help="""
+Filename pattern to use when creating output files.
+The sequential file number and the format are available.
+Default: cqobject-%%(counter)d.%%(format)s
+    """
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument("--output_format", action="store",help="Output Object format (TJS|STEP|STL|SVG)")
+    parser.add_argument("--param_file", action="store",help="Parameter Values File, in JSON format")
+    parser.add_argument("--in_file", action="store", help="Input File path. If omitted, read stdin")
+    parser.add_argument("--filename_pattern",action="store", default="cqobject-%(counter)d.%(format)s",help=filename_pattern_help)
+    parser.add_argument("--out_dir", action="store", help="Output File Directory. If omitted, current work directory is used")
+    args = parser.parse_args()
+
+    run(args)

--- a/cq_cmd.sh
+++ b/cq_cmd.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
+# NOTE
+# the -u (unbuffered flag) in the below is very important
+# without it, the FreeCAD libraries somehow manage to get some stdout
+# junking up output when stdout is used.
+# this is the script we use
+# to select between running a build server
+# and a command line job runner
 if [ -z "$1" ]; then
-   python /opt/cadquery/cq_cmd.py --help
-else
-   python /opt/cadquery/cq_cmd.py "$@"
+   echo "Usage: docker run cadquery build|server [options]"
+   exit(1)
+fi;
+if [ "$1" == "build"]; then
+   exec python -u /opt/cadquery/cq_cmd.py "$@"
+fi;
+if [ "$1" == "runserver"]; then
+   exec python -u /opt/cadquery/cq_server.py "$@"
 fi;

--- a/cq_cmd.sh
+++ b/cq_cmd.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ -z "$1" ]; then
-   python cq_cmd.py --help
+   python /opt/cadquery/cq_cmd.py --help
 else
-   python cq_cmd.py "$@"
+   python /opt/cadquery/cq_cmd.py "$@"
 fi;

--- a/cq_cmd.sh
+++ b/cq_cmd.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [ -z "$1" ]; then
+   python cq_cmd.py --help
+else
+   python cq_cmd.py "$@"
+fi;

--- a/cq_cmd.sh
+++ b/cq_cmd.sh
@@ -7,12 +7,28 @@
 # to select between running a build server
 # and a command line job runner
 if [ -z "$1" ]; then
-   echo "Usage: docker run cadquery build|server [options]"
-   exit(1)
+   echo "************************"
+   echo "CadQuery Docker Image"
+   echo "************************"
+   echo "Usage: docker run cadquery build [options]"
+   echo "Examples:"
+   echo " Read a model from stdin, write output to stdout"
+   echo ""
+   echo "    cat cadquery_script.py | sudo docker run -i dcowden/cadquery:latest --in_spec stdin --out_spec stdout > my_object.STEP"
+   echo " "
+   echo " Mount a directory, and write results into the local directory"
+   echo ""
+   echo "    sudo docker run -i dcowden/cadquery:latest --in_spec my_script.py"
+   echo ""
+   exec python -u /opt/cadquery/cq_cmd.py -h
+   exit 1
 fi;
-if [ "$1" == "build"]; then
-   exec python -u /opt/cadquery/cq_cmd.py "$@"
+if [ "$1" == "build" ]; then
+  echo "Launching python with arguments ${@:2}"
+   exec python -u /opt/cadquery/cq_cmd.py "${@:2}"
 fi;
-if [ "$1" == "runserver"]; then
-   exec python -u /opt/cadquery/cq_server.py "$@"
+if [ "$1" == "runserver" ]; then
+  echo "Future CadQuery Server"
+  exit 1
+   #exec python -u /opt/cadquery/cq_server.py "${@:2}"
 fi;

--- a/cq_cmd.sh
+++ b/cq_cmd.sh
@@ -24,7 +24,6 @@ if [ -z "$1" ]; then
    exit 1
 fi;
 if [ "$1" == "build" ]; then
-  echo "Launching python with arguments ${@:2}"
    exec python -u /opt/cadquery/cq_cmd.py "${@:2}"
 fi;
 if [ "$1" == "runserver" ]; then


### PR DESCRIPTION
This branch builds a docker image, which can execute cadquery scripts with a command line.
It includes all of the dependencies necessary to run cadquery.

A future version will allow starting as a web server that exposes an object build service. to get started:

`   docker run dcowden/cadquery:latest `

Will print out the documentation. Thoughts/comments welcome!
Not ready for merge yet.