### PR TITLE
cadquery.Plane equality

### DIFF
--- a/cadquery/freecad_impl/geom.py
+++ b/cadquery/freecad_impl/geom.py
@@ -289,6 +289,10 @@ class Plane(object):
     created automatically from faces.
     """
 
+    # equality tolerances
+    _eq_tolerance_origin = 1e-6
+    _eq_tolerance_dot = 1e-6
+
     @classmethod
     def named(cls, stdName, origin=(0, 0, 0)):
         """Create a predefined Plane based on the conventional names.
@@ -671,6 +675,22 @@ class Plane(object):
         """Computes the 2-d projection of the supplied matrix"""
 
         return Matrix(self.fG.multiply(tMatrix.wrapped).multiply(self.rG))
+
+    # Equality
+    def __eq__(self, other):
+        def equality_iter():
+            cls = type(self)
+            yield isinstance(other, Plane)  # comparison is with another Plane
+            # origins are the same
+            yield abs(self.origin - other.origin) < cls._eq_tolerance_origin
+            # z-axis vectors are parallel (assumption: both are unit vectors)
+            yield abs(self.zDir.dot(other.zDir) - 1) < cls._eq_tolerance_dot
+            # x-axis vectors are parallel (assumption: both are unit vectors)
+            yield abs(self.xDir.dot(other.xDir) - 1) < cls._eq_tolerance_dot
+        return all(equality_iter())
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 class BoundBox(object):

--- a/tests/TestCadObjects.py
+++ b/tests/TestCadObjects.py
@@ -201,6 +201,51 @@ class TestCadObjects(BaseTest):
         v = Vector(1, -2, 3)
         self.assertEqual(-v, Vector(-1, 2, -3))
 
+    def testPlaneEqual(self):
+        # default orientation
+        self.assertEqual(
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,0,1)),
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,0,1))
+        )
+        # moved origin
+        self.assertEqual(
+            Plane(origin=(2,1,-1), xDir=(1,0,0), normal=(0,0,1)),
+            Plane(origin=(2,1,-1), xDir=(1,0,0), normal=(0,0,1))
+        )
+        # moved x-axis
+        self.assertEqual(
+            Plane(origin=(0,0,0), xDir=(1,1,0), normal=(0,0,1)),
+            Plane(origin=(0,0,0), xDir=(1,1,0), normal=(0,0,1))
+        )
+        # moved z-axis
+        self.assertEqual(
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,1,1)),
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,1,1))
+        )
+
+    def testPlaneNotEqual(self):
+        # type difference
+        for value in [None, 0, 1, 'abc']:
+            self.assertNotEqual(
+                Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,0,1)),
+                value
+            )
+        # origin difference
+        self.assertNotEqual(
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,0,1)),
+            Plane(origin=(0,0,1), xDir=(1,0,0), normal=(0,0,1))
+        )
+        # x-axis difference
+        self.assertNotEqual(
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,0,1)),
+            Plane(origin=(0,0,0), xDir=(1,1,0), normal=(0,0,1))
+        )
+        # z-axis difference
+        self.assertNotEqual(
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,0,1)),
+            Plane(origin=(0,0,0), xDir=(1,0,0), normal=(0,1,1))
+        )
+
     def testTranslate(self):
         e = Shape.cast(Part.makeCircle(2.0, FreeCAD.Base.Vector(1, 2, 3)))
         e2 = e.translate(Vector(0, 0, 1))


### PR DESCRIPTION
Test equality (or inequality) of 2 `cadquery.Plane` instances.
effectively: do they coincide?

```python
>>> import cadquery
>>> p1 = cadquery.Plane(origin=(1,2,3), xDir=(10,5,0), normal=(0,0,4))
>>> p2 = cadquery.Plane(origin=(1,2,3), xDir=(1,0.5,0), normal=(0,0,2))
>>> p1 == p2
True
```