### PR TITLE
change filepath to new logo

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -144,7 +144,7 @@ html_title = "CadQuery Documentation"
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = "_static/cqlogo.png"
+html_logo = "_static/logo/cadquery_logo_dark.svg"
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32


### PR DESCRIPTION
Jeremy pointed out that a new logo exists. Currently the docs don't use it, so changing the filepath should fix this.