### PR TITLE
STEP URL Import Test

### DIFF
--- a/cadquery/freecad_impl/importers.py
+++ b/cadquery/freecad_impl/importers.py
@@ -8,7 +8,7 @@ import sys
 import os
 import urllib as urlreader
 import tempfile
-  
+
 class ImportTypes:
     STEP = "STEP"
 
@@ -34,10 +34,9 @@ def importStep(fileName):
     """
         Accepts a file name and loads the STEP file into a cadquery shape
         :param fileName: The path and name of the STEP file to be imported
-    """      
+    """
     #Now read and return the shape
     try:
-        #print fileName        
         rshape = Part.read(fileName)
 
         #Make sure that we extract all the solids
@@ -50,14 +49,19 @@ def importStep(fileName):
         raise ValueError("STEP File Could not be loaded")
 
 #Loads a STEP file from an URL into a CQ.Workplane object
-def importStepFromURL(url):    
+def importStepFromURL(url):
     #Now read and return the shape
     try:
-        webFile = urlreader.urlopen(url)
+        # Account for differences in urllib between Python 2 and 3
+        if hasattr(urlreader, "urlopen"):
+            webFile = urlreader.urlopen(url)
+        else:
+            webFile = urlreader.request.urlopen()
+
         tempFile = tempfile.NamedTemporaryFile(suffix='.step', delete=False)
         tempFile.write(webFile.read())
         webFile.close()
-        tempFile.close()  
+        tempFile.close()
 
         rshape = Part.read(tempFile.name)
 

--- a/cadquery/freecad_impl/importers.py
+++ b/cadquery/freecad_impl/importers.py
@@ -57,7 +57,7 @@ def importStepFromURL(url):
             webFile = urlreader.urlopen(url)
         else:
             import urllib.request
-            webFile = urlreader.request.urlopen(url)
+            webFile = urllib.request.urlopen(url)
 
         tempFile = tempfile.NamedTemporaryFile(suffix='.step', delete=False)
         tempFile.write(webFile.read())

--- a/cadquery/freecad_impl/importers.py
+++ b/cadquery/freecad_impl/importers.py
@@ -56,6 +56,7 @@ def importStepFromURL(url):
         if hasattr(urlreader, "urlopen"):
             webFile = urlreader.urlopen(url)
         else:
+            import urllib.request
             webFile = urlreader.request.urlopen()
 
         tempFile = tempfile.NamedTemporaryFile(suffix='.step', delete=False)

--- a/cadquery/freecad_impl/importers.py
+++ b/cadquery/freecad_impl/importers.py
@@ -57,7 +57,7 @@ def importStepFromURL(url):
             webFile = urlreader.urlopen(url)
         else:
             import urllib.request
-            webFile = urlreader.request.urlopen()
+            webFile = urlreader.request.urlopen(url)
 
         tempFile = tempfile.NamedTemporaryFile(suffix='.step', delete=False)
         tempFile.write(webFile.read())

--- a/tests/TestImporters.py
+++ b/tests/TestImporters.py
@@ -36,10 +36,10 @@ class TestImporters(BaseTest):
             # Reimport the shape from the new STEP file
             importedShape = importers.importShape(importType,fileName)
 
-            #Check to make sure we got a solid back
+            # Check to make sure we got a solid back
             self.assertTrue(importedShape.val().ShapeType() == "Solid")
 
-            #Check the number of faces and vertices per face to make sure we have a box shape
+            # Check the number of faces and vertices per face to make sure we have a box shape
             self.assertTrue(importedShape.faces("+X").size() == 1 and importedShape.faces("+X").vertices().size() == 4)
             self.assertTrue(importedShape.faces("+Y").size() == 1 and importedShape.faces("+Y").vertices().size() == 4)
             self.assertTrue(importedShape.faces("+Z").size() == 1 and importedShape.faces("+Z").vertices().size() == 4)
@@ -50,6 +50,22 @@ class TestImporters(BaseTest):
         """
         with suppress_stdout_stderr():
             self.importBox(importers.ImportTypes.STEP, OUTDIR + "/tempSTEP.step")
+
+    def testSTEPFromURL(self):
+        """
+        Tests STEP file import from a URL
+        """
+        stepURL = "https://raw.githubusercontent.com/easyw/kicadStepUpMod/master/demo/demo-fc16.step"
+
+        importedShape = importers.importStepFromURL(stepURL)
+
+        # Check to make sure we got a solid back
+        self.assertTrue(importedShape.val().ShapeType() == "Solid")
+
+        # Check the number of faces and vertices per face to make sure we have a box shape
+        self.assertTrue(importedShape.faces("+X").size() == 1 and importedShape.faces("+X").vertices().size() == 4)
+        self.assertTrue(importedShape.faces("+Y").size() == 1 and importedShape.faces("+Y").vertices().size() == 4)
+        self.assertTrue(importedShape.faces("+Z").size() == 1 and importedShape.faces("+Z").vertices().size() == 4)
 
 if __name__ == '__main__':
     import unittest

--- a/tests/TestImporters.py
+++ b/tests/TestImporters.py
@@ -55,7 +55,7 @@ class TestImporters(BaseTest):
         """
         Tests STEP file import from a URL
         """
-        stepURL = "https://raw.githubusercontent.com/easyw/kicadStepUpMod/master/demo/demo-fc16.step"
+        stepURL = "https://raw.githubusercontent.com/dcowden/cadquery/master/doc/_static/box_export.step"
 
         importedShape = importers.importStepFromURL(stepURL)
 


### PR DESCRIPTION
Importing a STEP file via a URL wasn't covered by tests and failed in Python 3. This is a fix for that both issues. If someone gets a chance, please have a look. Otherwise, I'll just merge it on my own sometime tomorrow. The only thing that bothers me a bit is the location of `import urllib.request`. The package was broken up into sections in Python 3, and that's the least error prone and most efficient way I could think of to handle it.