### PR TITLE
Better support for running from an Anaconda environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ matrix:
   include:
     - python: 2.7
     - python: 3.6
-      env: FREECAD_LIB="$HOME/miniconda/envs/freecad_cq3/lib/"
 
 before_install:
 - if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then

--- a/cadquery/freecad_impl/__init__.py
+++ b/cadquery/freecad_impl/__init__.py
@@ -18,6 +18,7 @@
 """
 import os
 import sys
+import glob
 
 
 #FreeCAD has crudified the stdout stream with a bunch of STEP output
@@ -59,6 +60,13 @@ def _fc_path():
     _PATH = os.environ.get('FREECAD_LIB', '')
     if _PATH and os.path.exists(_PATH):
         return _PATH
+
+    # Try to guess if using Anaconda
+    if 'env' in sys.prefix:
+        _PATH = os.path.join(sys.prefix,'lib')
+        # return PATH if FreeCAD.[so,pyd] is present
+        if len(glob.glob(os.path.join(_PATH,'FreeCAD.*'))) > 0:
+            return _PATH
 
     if sys.platform.startswith('linux'):
         # Make some dangerous assumptions...


### PR DESCRIPTION
The purpose of this PR is to make running cq with Anaconda more user friendly. If everything works fine there will be no need to define `FREECAD_LIB` environment variable.