### PR TITLE
Dont install freecad-doc in the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   else
     sudo add-apt-repository -y ppa:freecad-maintainers/freecad-stable;
     sudo apt-get update -qq;
-    sudo apt-get install -y freecad freecad-doc;
+    sudo apt-get install -y freecad;
     pip install -r requirements-dev.txt;
     pip install travis-sphinx;
     pip install sphinx_rtd_theme;


### PR DESCRIPTION
The freecad-doc package download weighs in at about 150 MB and adds several
minutes to the travis build time for no purpose (not that I know of that is :smile: ).