### PR TITLE
Switched to Miniconda and added cqparts to Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificate
     git mercurial subversion
 
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/archive/Anaconda2-5.0.0-Linux-x86_64.sh -O ~/anaconda.sh && \
-    /bin/bash ~/anaconda.sh -b -p /opt/conda && \
-    rm ~/anaconda.sh
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh
 
 RUN apt-get install -y curl grep sed dpkg  && \
     TINI_VERSION=`curl https://github.com/krallin/tini/releases/latest | grep -o "/v.*\"" | sed 's:^..\(.*\).$:\1:'` && \
@@ -42,6 +42,10 @@ COPY tests $CQ_HOME/tests
 
 RUN pip install -r /opt/cadquery/requirements-dev.txt
 RUN cd $CQ_HOME && python ./setup.py install
+RUN pip install cqparts
+RUN pip install cqparts-bearings
+RUN pip install cqparts-fasteners
+RUN pip install cqparts-misc
 RUN chmod +x $CQ_HOME/cq_cmd.sh
 RUN useradd -ms /bin/bash cq
 USER cq


### PR DESCRIPTION
@dcowden This does technically work, but treat it as a WIP until I get a more real-world test done. I'm making these changes to support the STEMN work, and so a mock setup of doing a conversion will probably be the test. I'm guessing there will be issues due to the CQGI `show_object` and cqparts `display` differences though.

This change adds cqparts and it's sub-libraries to the Dockerfile since cqparts is becoming such a crucial part of the CadQuery ecosystem. I also switched to Miniconda, which dropped the image size from 4.09GB to 1.74GB.

@fragmuffin @adam-urbanczyk This might be something you will at least want to be aware of too.