### PR TITLE
include LICENSE in bundles

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.md
+include README.md LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
Thanks for all the work! 

This adds `LICENSE` to distributions (source, wheel) to comply with the [Apache 2.0 license](http://www.apache.org/foundation/license-faq.html#WhatDoesItMEAN).
