### PR TITLE
Also detect FreeCAD from conda on OSX

### DIFF
--- a/cadquery/freecad_impl/__init__.py
+++ b/cadquery/freecad_impl/__init__.py
@@ -63,7 +63,7 @@ def _fc_path():
 
     # Try to guess if using Anaconda
     if 'env' in sys.prefix:
-        if sys.platform.startswith('linux'):
+        if sys.platform.startswith('linux') or sys.platform.startswith('darwin'):
             _PATH = os.path.join(sys.prefix,'lib')
             # return PATH if FreeCAD.[so,pyd] is present
             if len(glob.glob(os.path.join(_PATH,'FreeCAD.so'))) > 0:


### PR DESCRIPTION
Now that freecad is [installable from conda-forge on linux/osx/win](https://anaconda.org/conda-forge/freecad/files), this also checks in `$PREFIX/lib` on OSX. 

Big thanks to @loooo for suggesting this simple fix over on the [conda-forge PR for cadquery](https://github.com/conda-forge/staged-recipes/pull/6163), where we're basically applying this patch, as well as getting FreeCAD through the conda-forge process!