### PR TITLE
Add polarLine and polarLineTo methods

### DIFF
--- a/cadquery/cq.py
+++ b/cadquery/cq.py
@@ -1220,6 +1220,35 @@ class Workplane(CQ):
         p = self._findFromPoint(True)
         return self.lineTo(xCoord, p.y, forConstruction)
 
+    def polarLine(self, distance, angle, forConstruction=False):
+        """
+        Make a line of the given length, at the given angle from the current point
+
+        :param float distance: distance of the end of the line from the current point
+        :param float angle: angle of the vector to the end of the line with the x-axis
+        :return: the Workplane object with the current point at the end of the new line
+       """
+        x = math.cos(math.radians(angle)) * distance
+        y = math.sin(math.radians(angle)) * distance
+
+        return self.line(x, y, forConstruction)
+
+    def polarLineTo(self, distance, angle, forConstruction=False):
+        """
+        Make a line from the current point to the given polar co-ordinates
+
+        Useful if it is more convenient to specify the end location rather than
+        the distance and angle from the current point
+
+        :param float distance: distance of the end of the line from the origin
+        :param float angle: angle of the vector to the end of the line with the x-axis
+        :return: the Workplane object with the current point at the end of the new line
+        """
+        x = math.cos(math.radians(angle)) * distance
+        y = math.sin(math.radians(angle)) * distance
+
+        return self.lineTo(x, y, forConstruction)
+
     #absolute move in current plane, not drawing
     def moveTo(self, x=0, y=0):
         """

--- a/tests/TestCadQuery.py
+++ b/tests/TestCadQuery.py
@@ -881,6 +881,23 @@ class TestCadQuery(BaseTest):
         assert(a1.edges().first().val().Length() == a2.edges().first().val().Length())
         assert(a3.edges().first().val().Length() == a4.edges().first().val().Length())
 
+    def testPolarLines(self):
+        """
+        Draw some polar lines and check expected results
+        """
+
+        # Test the PolarLine* functions
+        s = Workplane(Plane.XY())
+        r = s.polarLine(10, 45) \
+            .polarLineTo(10, -45) \
+            .polarLine(10, -180) \
+            .polarLine(-10, -90) \
+            .close()
+
+        # a single wire, 5 edges
+        self.assertEqual(1, r.wires().size())
+        self.assertEqual(5, r.wires().edges().size())
+
     def testLargestDimension(self):
         """
         Tests the largestDimension function when no solids are on the stack and when there are


### PR DESCRIPTION
Useful for defining lines when you know the length and angle, rather than
the Cartesian co-ordinates.

Based on issue #291 